### PR TITLE
Towards multi stage movegen

### DIFF
--- a/engine/position.go
+++ b/engine/position.go
@@ -1,5 +1,9 @@
 package engine
 
+import (
+	"math/bits"
+)
+
 type Position struct {
 	Board         Bitboard
 	EnPassant     Square
@@ -390,7 +394,15 @@ func (p *Position) IsDraw() bool {
 			// one side has a king and a minor piece against a bare king
 
 			if all <= 1 {
-				return true
+				if wKnightsNum != 0 {
+					return bits.OnesCount64(p.Board.whiteKnight) == 1
+				} else if bKnightsNum != 0 {
+					return bits.OnesCount64(p.Board.blackKnight) == 1
+				} else if wBishopsNum != 0 {
+					return bits.OnesCount64(p.Board.whiteBishop) == 1
+				} else if bBishopsNum != 0 {
+					return bits.OnesCount64(p.Board.blackBishop) == 1
+				}
 			}
 			// both sides have a king and a bishop, the bishops being the same color
 			if wKnightsNum == 0 && bKnightsNum == 0 {

--- a/search/movepicker.go
+++ b/search/movepicker.go
@@ -26,6 +26,7 @@ func NewMovePicker(p *Position, e *Engine, moveOrder int8, hashmove Move, isQuie
 		0,
 		isQuiescence,
 	}
+	mp.generateMoves()
 	return mp
 }
 
@@ -38,7 +39,6 @@ func (mp *MovePicker) generateMoves() {
 	} else {
 		mp.moves = mp.position.LegalMoves()
 	}
-	mp.generateMoves()
 	mp.score()
 }
 
@@ -60,10 +60,13 @@ func (mp *MovePicker) UpgradeToPvMove(pvMove Move) {
 	mp.hashmove = pvMove
 	if mp.moves != nil {
 		for i := 0; i < len(mp.moves); i++ {
-			mp.scores[i] = 900_000_000
-			mp.scores[0], mp.scores[i] = mp.scores[i], mp.scores[0]
-			mp.moves[0], mp.moves[i] = mp.moves[i], mp.moves[0]
-			break
+			move := mp.moves[i]
+			if move == mp.hashmove {
+				mp.scores[i] = 900_000_000
+				mp.scores[0], mp.scores[i] = mp.scores[i], mp.scores[0]
+				mp.moves[0], mp.moves[i] = mp.moves[i], mp.moves[0]
+				break
+			}
 		}
 	}
 }
@@ -178,15 +181,13 @@ func (mp *MovePicker) Next() Move {
 		return EmptyMove
 	}
 
-	var best = mp.moves[mp.next]
 	var bestIndex = mp.next
 	for i := mp.next + 1; i < len(mp.moves); i++ {
-		move := mp.moves[i]
 		if mp.scores[i] > mp.scores[bestIndex] {
-			best = move
 			bestIndex = i
 		}
 	}
+	var best = mp.moves[bestIndex]
 	mp.moves[mp.next], mp.moves[bestIndex] = mp.moves[bestIndex], mp.moves[mp.next]
 	mp.scores[mp.next], mp.scores[bestIndex] = mp.scores[bestIndex], mp.scores[mp.next]
 	mp.next += 1

--- a/search/movepicker_test.go
+++ b/search/movepicker_test.go
@@ -1,0 +1,29 @@
+package search
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/amanjpro/zahak/engine"
+)
+
+func TestMovepickerNext(t *testing.T) {
+	mp := &MovePicker{
+		nil,
+		nil,
+		10,
+		[]Move{10, 5, 4, 8, 3, 2, 1, 6, 7, 9},
+		[]int32{1000, 500, 400, 800, 300, 200, 100, 600, 700, 900},
+		0,
+		0,
+		false,
+	}
+
+	for i := 0; i < mp.Length(); i++ {
+		actual := mp.Next()
+		expected := mp.Length() - i
+		if actual != Move(expected) {
+			t.Error(fmt.Sprintf("Expected %d But got %d\n", expected, int32(actual)))
+		}
+	}
+}

--- a/search/quiescence.go
+++ b/search/quiescence.go
@@ -45,9 +45,9 @@ func (e *Engine) quiescence(position *Position, alpha int16, beta int16, current
 		isCheckMove := move.IsCheck()
 		isCaptureMove := move.IsCapture()
 		if !isInCheck && isCaptureMove && !isCheckMove && !move.IsEnPassant() {
-			// SEE pruning
-			e.info.seeQuiescenceCounter += 1
 			if movePicker.scores[i] < 0 {
+				// SEE pruning
+				e.info.seeQuiescenceCounter += 1
 				continue
 			}
 		}

--- a/search/quiescence.go
+++ b/search/quiescence.go
@@ -37,12 +37,10 @@ func (e *Engine) quiescence(position *Position, alpha int16, beta int16, current
 		alpha = standPat
 	}
 
-	withChecks := false && ply < 4
-	legalMoves := position.QuiesceneMoves(withChecks)
+	// withChecks := false && ply < 4
+	movePicker := NewMovePicker(position, e, searchHeight, EmptyMove, true)
 
-	movePicker := NewMovePicker(position, e, legalMoves, searchHeight, EmptyMove)
-
-	for i := 0; i < len(legalMoves); i++ {
+	for i := 0; i < movePicker.Length(); i++ {
 		move := movePicker.Next()
 		isCheckMove := move.IsCheck()
 		isCaptureMove := move.IsCapture()

--- a/search/search.go
+++ b/search/search.go
@@ -117,6 +117,16 @@ func (e *Engine) alphaBeta(position *Position, depthLeft int8, searchHeight int8
 		}
 	}
 
+	if nHashMove == EmptyMove && !position.HasLegalMoves() {
+		if isInCheck {
+			e.innerLines[searchHeight].Recycle()
+			return -CHECKMATE_EVAL, true
+		} else {
+			e.innerLines[searchHeight].Recycle()
+			return 0, true
+		}
+	}
+
 	if e.ShouldStop() {
 		e.innerLines[searchHeight].Recycle()
 		return -MAX_INT, false
@@ -145,17 +155,6 @@ func (e *Engine) alphaBeta(position *Position, depthLeft int8, searchHeight int8
 			e.info.nullMoveCounter += 1
 			e.innerLines[searchHeight].Recycle()
 			return beta, true // null move pruning
-		}
-	}
-
-	legalMoves := position.LegalMoves()
-	if len(legalMoves) == 0 {
-		if isInCheck {
-			e.innerLines[searchHeight].Recycle()
-			return -CHECKMATE_EVAL, true
-		} else {
-			e.innerLines[searchHeight].Recycle()
-			return 0, true
 		}
 	}
 
@@ -190,6 +189,7 @@ func (e *Engine) alphaBeta(position *Position, depthLeft int8, searchHeight int8
 		}
 	}
 
+	legalMoves := position.LegalMoves()
 	movePicker := NewMovePicker(position, e, legalMoves, searchHeight, nHashMove)
 
 	// Internal Iterative Deepening

--- a/search/search.go
+++ b/search/search.go
@@ -189,8 +189,7 @@ func (e *Engine) alphaBeta(position *Position, depthLeft int8, searchHeight int8
 		}
 	}
 
-	legalMoves := position.LegalMoves()
-	movePicker := NewMovePicker(position, e, legalMoves, searchHeight, nHashMove)
+	movePicker := NewMovePicker(position, e, searchHeight, nHashMove, false)
 
 	// Internal Iterative Deepening
 	if depthLeft >= 8 && !movePicker.HasPVMove() {
@@ -205,7 +204,7 @@ func (e *Engine) alphaBeta(position *Position, depthLeft int8, searchHeight int8
 	M := 6
 	C := 3
 	R = 4
-	if !isRootNode && !isPvNode && depthLeft > R && searchHeight > 3 && multiCutFlag && len(legalMoves) > M {
+	if !isRootNode && !isPvNode && depthLeft > R && searchHeight > 3 && multiCutFlag && movePicker.Length() > M {
 		cutNodeCounter := 0
 		for i := 0; i < M; i++ {
 			move := movePicker.Next()
@@ -266,7 +265,7 @@ func (e *Engine) alphaBeta(position *Position, depthLeft int8, searchHeight int8
 		e.AddMoveHistory(move, move.MovingPiece(), move.Destination(), searchHeight)
 	}
 
-	for i := 1; i < len(legalMoves); i++ {
+	for i := 1; i < movePicker.Length(); i++ {
 		move := movePicker.Next()
 		if isRootNode {
 			fmt.Printf("info depth %d currmove %s currmovenumber %d\n", depthLeft, move.ToString(), i+1)

--- a/search/types.go
+++ b/search/types.go
@@ -195,7 +195,7 @@ func (e *Engine) SendPv(depth int8) {
 	thinkTime := time.Now().Sub(e.StartTime)
 	fmt.Printf("info depth %d seldepth %d tbhits %d hashfull %d nodes %d nps %d, score cp %d time %d pv %s\n",
 		depth, e.pv.moveCount, e.cacheHits, e.TranspositionTable.Consumed(),
-		e.nodesVisited, int64(float64(e.nodesVisited)/thinkTime.Seconds()*1000), e.score,
+		e.nodesVisited, int64(float64(e.nodesVisited)/thinkTime.Seconds()), e.score,
 		thinkTime.Milliseconds(), e.pv.ToString())
 }
 

--- a/search/types.go
+++ b/search/types.go
@@ -193,8 +193,9 @@ func (e *Engine) SendPv(depth int8) {
 		depth = e.pv.moveCount
 	}
 	thinkTime := time.Now().Sub(e.StartTime)
-	fmt.Printf("info depth %d seldepth %d tbhits %d hashfull %d nodes %d score cp %d time %d pv %s\n",
-		depth, e.pv.moveCount, e.cacheHits, e.TranspositionTable.Consumed(), e.nodesVisited, e.score,
+	fmt.Printf("info depth %d seldepth %d tbhits %d hashfull %d nodes %d nps %d, score cp %d time %d pv %s\n",
+		depth, e.pv.moveCount, e.cacheHits, e.TranspositionTable.Consumed(),
+		e.nodesVisited, int64(float64(e.nodesVisited)/thinkTime.Seconds()*1000), e.score,
 		thinkTime.Milliseconds(), e.pv.ToString())
 }
 


### PR DESCRIPTION
Mostly refactoring, and delaying movegen in case there is a hashmove. Also fixes IID

Elo wise:
- In short time control, the strength is more or less the same (1m + 1s)
```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   WWins  WLoss.  WDraws   BWins  BLoss.  BDraws 
   0 zahak_next                     88      22     800     414     216     170    499.0     226      92      82     188     124      88 
   1 zahak_master                   -2      40     200      67      68      65     99.5      35      31      34      32      37      31 
   2 vice                          -78      46     200      66     110      24     78.0      40      48      12      26      62      12 
   3 rustic                       -139      48     200      49     125      26     62.0      30      60      10      19      65      16 
   4 zahak-darwin-amd64-latest    -141      43     200      34     111      55     61.5      19      49      32      15      62      23 
```

- In longer time control, a mach is going on with `zahak_master` they seem to be on par (15m per 40moves):
```
Score of zahak_next vs zahak_master: 5 - 2 - 5  [0.625] 12
...      zahak_next playing White: 3 - 0 - 3  [0.750] 6
...      zahak_next playing Black: 2 - 2 - 2  [0.500] 6
...      White vs Black: 5 - 2 - 5  [0.625] 12
Elo difference: 88.7 +/- 164.7, LOS: 87.2 %, DrawRatio: 41.7 %
```