### PR TITLE
Allow LMR in root nodes, and tweak NMP

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -201,9 +201,9 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 		(searchHeight > 2 && e.staticEvals[searchHeight] > e.staticEvals[searchHeight-2])
 
 	// Pruning
-	reductionsAllowed := !isRootNode && !isPvNode && !isInCheck
+	reductionsAllowed := (!isPvNode || isPvNode && isRootNode && depthLeft > 3) && !isInCheck
 
-	if reductionsAllowed {
+	if reductionsAllowed && !isRootNode {
 		// Razoring
 		// razoringMargin := r
 		// if improving {
@@ -230,8 +230,8 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 		// NullMove pruning
 		isNullMoveAllowed := currentMove != EmptyMove && !position.IsEndGame()
 		if isNullMoveAllowed && depthLeft >= 2 && eval > beta {
-			var R = 4 + depthLeft/6
-			if eval >= beta+p {
+			var R = 4 + depthLeft/5
+			if eval >= beta+50 {
 				R = min8(R, depthLeft)
 			} else {
 				R = min8(R, depthLeft-1)
@@ -427,6 +427,10 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 							position.UnMakeMove(move, oldTag, oldEnPassant, hc)
 							continue
 						}
+					}
+
+					if isPvNode {
+						LMR = max8(1, LMR-1)
 					}
 
 					LMR = min8(depthLeft-2, LMR)

--- a/search/types.go
+++ b/search/types.go
@@ -365,3 +365,10 @@ func min8(x int8, y int8) int8 {
 	}
 	return x
 }
+
+func max8(x int8, y int8) int8 {
+	if x <= y {
+		return y
+	}
+	return x
+}


### PR DESCRIPTION
```
Score of zahak_next vs zahak_master: 717 - 627 - 1656  [0.515] 3000
...      zahak_next playing White: 427 - 239 - 834  [0.563] 1500
...      zahak_next playing Black: 290 - 388 - 822  [0.467] 1500
...      White vs Black: 815 - 529 - 1656  [0.548] 3000
Elo difference: 10.4 +/- 8.3, LOS: 99.3 %, DrawRatio: 55.2 %
Finished match
```