### PR TITLE
Reduce less aggressively in LMR

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -348,7 +348,6 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 	}
 	seeScores := movePicker.captureMoveList.Scores
 	quietScores := movePicker.quietMoveList.Scores
-	historyPruningThreashold := -1000 * int32(depthLeft)
 	var move Move
 	for true {
 
@@ -434,7 +433,7 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 					LMR -= 1
 				}
 
-				if quietScores[quietMoves] > historyPruningThreashold {
+				if quietScores[quietMoves] > 0 {
 					LMR -= 1
 				}
 


### PR DESCRIPTION
```
Score of zahak_next vs zahak-linux-amd64-5.0: 1173 - 1082 - 2745  [0.509] 5000
...      zahak_next playing White: 709 - 427 - 1364  [0.556] 2500
...      zahak_next playing Black: 464 - 655 - 1381  [0.462] 2500
...      White vs Black: 1364 - 891 - 2745  [0.547] 5000
Elo difference: 6.3 +/- 6.5, LOS: 97.2 %, DrawRatio: 54.9 %
```