### PR TITLE
Little tweaks in NMP and Razoring

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -211,7 +211,7 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 
 	if pruningAllowed {
 		// Razoring
-		if depthLeft <= 2 && eval+r < beta {
+		if depthLeft < 3 && eval+b < beta {
 			newEval := e.quiescence(alpha, beta, searchHeight)
 			e.info.razoringCounter += 1
 			return newEval
@@ -230,7 +230,7 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 		// NullMove pruning
 		isNullMoveAllowed := currentMove != EmptyMove && !position.IsEndGame()
 		if isNullMoveAllowed && depthLeft >= 2 && eval > beta {
-			var R = 4 + depthLeft/5
+			var R = 4 + depthLeft/4
 			if eval >= beta+50 {
 				R = min8(R, depthLeft)
 			} else {


### PR DESCRIPTION
```
Score of zahak_next vs zahak_master: 1430 - 1318 - 3378  [0.509] 6126
...      zahak_next playing White: 827 - 511 - 1726  [0.552] 3064
...      zahak_next playing Black: 603 - 807 - 1652  [0.467] 3062
...      White vs Black: 1634 - 1114 - 3378  [0.542] 6126
Elo difference: 6.4 +/- 5.8, LOS: 98.4 %, DrawRatio: 55.1 %
```