### PR TITLE
Add logic for ProbCut

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The history of Zahak's rating is summerized here:
 - Internal Iterative Deepening (for PV nodes only)
 - Internal Iterative Reduction (for non-PV nodes only)
 - SEE pruning both in QS and normal search
+- ProbCut
 
 ## Evaluation
 

--- a/search/search.go
+++ b/search/search.go
@@ -250,6 +250,54 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 				}
 			}
 		}
+
+		// Prob cut
+		// The idea is basically cherry picked from multiple engines, Weiss, Ethereal and Berserk for example
+		probBeta := min16(beta+110, WIN_IN_MAX)
+		if depthLeft > 4 && abs16(beta) < WIN_IN_MAX && !(ttHit && nDepth >= depthLeft-3 && nEval < probBeta) {
+
+			hashMove := EmptyMove
+			if hashMove.IsCapture() || hashMove.PromoType() != NoType {
+				hashMove = nHashMove
+			}
+			movePicker := e.MovePickers[searchHeight]
+			movePicker.RecycleWith(position, e, depthLeft, hashMove, true)
+			seeScores := movePicker.captureMoveList.Scores
+			i := 0
+			for true {
+				move := movePicker.Next()
+				if move == EmptyMove || seeScores[i] < 0 {
+					break
+				}
+				if oldEnPassant, oldTag, hc, ok := position.MakeMove(move); ok {
+					var score int16
+					if depthLeft >= 8 {
+						e.innerLines[searchHeight+1].Recycle()
+						e.pred.Push(position.Hash())
+						e.positionMoves[searchHeight+1] = move
+						childEval := Evaluate(position)
+						e.staticEvals[searchHeight] = childEval
+						score = -e.quiescence(-probBeta, -probBeta+1, searchHeight+1)
+						e.pred.Pop()
+					}
+
+					if depthLeft < 8 || score >= probBeta {
+						e.innerLines[searchHeight+1].Recycle()
+						e.pred.Push(position.Hash())
+						e.positionMoves[searchHeight+1] = move
+						score = -e.alphaBeta(depthLeft-4, searchHeight+1, -probBeta, -probBeta+1)
+						e.pred.Pop()
+					}
+					position.UnMakeMove(move, oldTag, oldEnPassant, hc)
+
+					if score >= probBeta {
+						e.info.probCutCounter += 1
+						return score
+					}
+				}
+				i += 1
+			}
+		}
 	}
 
 	// Internal Iterative Deepening

--- a/search/types.go
+++ b/search/types.go
@@ -28,6 +28,7 @@ type Info struct {
 	quiesceCounter             int
 	killerCounter              int
 	historyCounter             int
+	probCutCounter             int
 	historyPruningCounter      int
 	internalIterativeReduction int
 }
@@ -41,6 +42,7 @@ func (i *Info) Print() {
 	fmt.Printf("info string Check Extension: %d\n", i.checkExtentionCounter)
 	fmt.Printf("info string Null-Move: %d\n", i.nullMoveCounter)
 	fmt.Printf("info string LMR: %d\n", i.lmrCounter)
+	fmt.Printf("info string ProbCut: %d\n", i.probCutCounter)
 	fmt.Printf("info string Delta Pruning: %d\n", i.deltaPruningCounter)
 	fmt.Printf("info string SEE Quiescence: %d\n", i.seeQuiescenceCounter)
 	fmt.Printf("info string SEE: %d\n", i.seeCounter)
@@ -129,7 +131,7 @@ func (e *Engine) AttachTimeManager(tm *TimeManager) {
 	e.TimeManager = tm
 }
 
-var NoInfo = Info{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+var NoInfo = Info{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 
 func (e *Engine) ClearForSearch() {
 	for i := 0; i < len(e.innerLines); i++ {


### PR DESCRIPTION
I tried multiple variants, and this one did the best (still not great
though):

```
Score of zahak_next vs zahak_master: 2212 - 2124 - 5664  [0.504] 10000
...      zahak_next playing White: 1364 - 813 - 2823  [0.555] 5000
...      zahak_next playing Black: 848 - 1311 - 2841  [0.454] 5000
...      White vs Black: 2675 - 1661 - 5664  [0.551] 10000
Elo difference: 3.1 +/- 4.5, LOS: 90.9 %, DrawRatio: 56.6 %
Finished match
```