### PR TITLE
Re-Add history pruning

### DIFF
--- a/search/types.go
+++ b/search/types.go
@@ -191,12 +191,16 @@ func (e *Engine) KillerMoveScore(move Move, depthLeft int8) int32 {
 		return 0
 	}
 	if e.killerMoves[depthLeft][0] == move {
-		return 100_000
+		return 90_000_000
 	}
 	if e.killerMoves[depthLeft][1] == move {
-		return 90_000
+		return 80_000_000
 	}
 	return 0
+}
+
+func historyBonus(current int32, bonus int32) int32 {
+	return current + 32*bonus - current*abs32(bonus)/512
 }
 
 func (e *Engine) AddHistory(move Move, movingPiece Piece, destination Square, depthLeft int8, searchHeight int8, quietMovesCounter int) {
@@ -213,7 +217,7 @@ func (e *Engine) AddHistory(move Move, movingPiece Piece, destination Square, de
 
 		e.RemoveMoveHistory(move, quietMovesCounter, depthLeft, searchHeight)
 		e.info.historyCounter += 1
-		e.searchHistory[movingPiece-1][destination] += int32(depthLeft * depthLeft)
+		e.searchHistory[movingPiece-1][destination] = historyBonus(e.searchHistory[movingPiece-1][destination], int32(depthLeft*depthLeft))
 	}
 }
 
@@ -234,9 +238,9 @@ func (e *Engine) RemoveMoveHistory(killerMove Move, quietMovesCounter int, depth
 		destination := move.Destination()
 		movingPiece := move.MovingPiece()
 		if move != killerMove && move.PromoType() == NoType && !move.IsCapture() /* && e.searchHistory[movingPiece-1][destination] != 0 */ {
-			value := e.searchHistory[movingPiece-1][destination] - int32(depthLeft*depthLeft)
-
-			e.searchHistory[movingPiece-1][destination] = value
+			// value := e.searchHistory[movingPiece-1][destination] - int32(depthLeft*depthLeft)
+			// e.searchHistory[movingPiece-1][destination] = value
+			e.searchHistory[movingPiece-1][destination] = historyBonus(e.searchHistory[movingPiece-1][destination], -int32(depthLeft*depthLeft))
 		}
 	}
 }
@@ -368,6 +372,13 @@ func IsPromoting(move Move) bool {
 	default:
 		return false
 	}
+}
+
+func abs32(x int32) int32 {
+	if x < 0 {
+		return -x
+	}
+	return x
 }
 
 func abs16(x int16) int16 {


### PR DESCRIPTION
```
Score of zahak_next vs zahak_master: 509 - 424 - 1084  [0.521] 2017
...      zahak_next playing White: 311 - 162 - 535  [0.574] 1008
...      zahak_next playing Black: 198 - 262 - 549  [0.468] 1009
...      White vs Black: 573 - 360 - 1084  [0.553] 2017
Elo difference: 14.7 +/- 10.3, LOS: 99.7 %, DrawRatio: 53.7 %
SPRT: llr 2.98 (101.3%), lbound -2.94, ubound 2.94 - H1 was accepted
Finished match
```