### PR TITLE
Tweak Razoring margin

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -204,7 +204,8 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 
 	if pruningAllowed {
 		// Razoring
-		if depthLeft < 3 && eval+b < beta {
+		razoringMargin := eval + int16(depthLeft)*p + p
+		if depthLeft < 3 && eval+razoringMargin < beta {
 			newEval := e.quiescence(alpha, beta, searchHeight)
 			e.info.razoringCounter += 1
 			return newEval


### PR DESCRIPTION
```
Score of zahak_next vs zahak_master: 1373 - 1322 - 3188  [0.504] 5883
...      zahak_next playing White: 830 - 520 - 1591  [0.553] 2941
...      zahak_next playing Black: 543 - 802 - 1597  [0.456] 2942
...      White vs Black: 1632 - 1063 - 3188  [0.548] 5883
Elo difference: 3.0 +/- 6.0, LOS: 83.7 %, DrawRatio: 54.2 %
SPRT: llr -2.38 (-80.9%), lbound -2.94, ubound 2.94
Started game 5897 of 40000 (zahak_next vs zahak_master)
```