### PR TITLE
Start reverse futility pruning one ply earlier

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -216,7 +216,7 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 		if improving {
 			reverseFutilityMargin += p // int16(depthLeft) * p
 		}
-		if depthLeft < 7 && eval-reverseFutilityMargin >= beta {
+		if depthLeft < 8 && eval-reverseFutilityMargin >= beta {
 			e.info.rfpCounter += 1
 			return eval - reverseFutilityMargin /* fail soft */
 		}


### PR DESCRIPTION
```
Score of zahak_next vs zahak_master: 1577 - 1426 - 3622  [0.511] 6625
...      zahak_next playing White: 957 - 548 - 1809  [0.562] 3314
...      zahak_next playing Black: 620 - 878 - 1813  [0.461] 3311
...      White vs Black: 1835 - 1168 - 3622  [0.550] 6625
Elo difference: 7.9 +/- 5.6, LOS: 99.7 %, DrawRatio: 54.7 %
SPRT: llr 2.38 (81.0%), lbound -2.94, ubound 2.94
```