### PR TITLE
Have LMR even for check moves

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -447,7 +447,7 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 			}
 
 			// Late Move Reduction
-			if !isInCheck && e.doPruning && isQuiet && !isCheckMove && depthLeft > 2 && legalMoves > lmrThreashold {
+			if !isInCheck && e.doPruning && isQuiet && depthLeft > 2 && legalMoves > lmrThreashold {
 				e.info.lmrCounter += 1
 				LMR = int8(lmrReductions[min8(31, depthLeft)][min(31, legalMoves)])
 


### PR DESCRIPTION
```
Score of zahak_next vs zahak_master: 1842 - 1659 - 4215  [0.512] 7716
...      zahak_next playing White: 1091 - 645 - 2123  [0.558] 3859
...      zahak_next playing Black: 751 - 1014 - 2092  [0.466] 3857
...      White vs Black: 2105 - 1396 - 4215  [0.546] 7716
Elo difference: 8.2 +/- 5.2, LOS: 99.9 %, DrawRatio: 54.6 %
SPRT: llr 2.96 (100.4%), lbound -2.94, ubound 2.94 - H1 was accepted
Finished match
```