### PR TITLE
Add singular extension and multi-cut

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ The history of Zahak's rating is summerized here:
 - Internal Iterative Reduction (for non-PV nodes only)
 - SEE pruning both in QS and normal search
 - ProbCut
+- Singular Extension
+- Multi-Cut
 
 ## Evaluation
 

--- a/search/types.go
+++ b/search/types.go
@@ -45,7 +45,9 @@ type Info struct {
 	killerCounter              int64
 	historyCounter             int64
 	probCutCounter             int64
+	singularExtensionCounter   int64
 	historyPruningCounter      int64
+	multiCutCounter            int64
 	internalIterativeReduction int64
 }
 
@@ -70,6 +72,8 @@ func (e *Engine) ShareInfo() {
 	atomic.AddInt64(&e.parent.globalInfo.probCutCounter, e.info.probCutCounter)
 	atomic.AddInt64(&e.parent.globalInfo.historyPruningCounter, e.info.historyPruningCounter)
 	atomic.AddInt64(&e.parent.globalInfo.internalIterativeReduction, e.info.internalIterativeReduction)
+	atomic.AddInt64(&e.parent.globalInfo.singularExtensionCounter, e.info.singularExtensionCounter)
+	atomic.AddInt64(&e.parent.globalInfo.multiCutCounter, e.info.multiCutCounter)
 
 	atomic.AddInt64(&e.parent.nodesVisited, e.nodesVisited)
 	atomic.AddInt64(&e.parent.cacheHits, e.cacheHits)
@@ -98,6 +102,8 @@ func (i *Info) Print() {
 	fmt.Printf("info string Killer Moves: %d\n", i.killerCounter)
 	fmt.Printf("info string History Moves: %d\n", i.historyCounter)
 	fmt.Printf("info string History Pruning: %d\n", i.historyPruningCounter)
+	fmt.Printf("info string Singular Extension: %d\n", i.singularExtensionCounter)
+	fmt.Printf("info string Multi-Cut: %d\n", i.multiCutCounter)
 	fmt.Printf("info string Internal Iterative Reduction: %d\n", i.internalIterativeReduction)
 }
 
@@ -124,6 +130,9 @@ type Engine struct {
 	StartTime          time.Time
 	parent             *Runner
 	startDepth         int8
+	skipMove           Move
+	skipHeight         int8
+	TempMovePicker     *MovePicker
 }
 
 var MAX_DEPTH int8 = int8(100)
@@ -184,6 +193,9 @@ func NewEngine(tt *Cache, ph *PawnCache, parent *Runner) *Engine {
 		doPruning:          false,
 		isMainThread:       false,
 		parent:             parent,
+		TempMovePicker:     EmptyMovePicker(),
+		skipMove:           EmptyMove,
+		skipHeight:         MAX_DEPTH,
 	}
 }
 
@@ -197,7 +209,7 @@ func (r *Runner) Ponderhit() {
 	fmt.Printf("info nodes %d\n", r.nodesVisited)
 }
 
-var NoInfo = Info{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+var NoInfo = Info{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 
 func (r *Runner) ClearForSearch() {
 	r.nodesVisited = 0
@@ -223,6 +235,9 @@ func (e *Engine) ClearForSearch() {
 			e.killerMoves[i][j] = EmptyMove
 		}
 	}
+
+	e.skipMove = EmptyMove
+	e.skipHeight = MAX_DEPTH
 
 	for i := 0; i < len(e.searchHistory); i++ {
 		if e.searchHistory[i] == nil {


### PR DESCRIPTION
```
Finished game 8983 (zahak_next vs zahak_master): * {No result}
Score of zahak_next vs zahak_master: 2094 - 1968 - 4925  [0.507] 8987
...      zahak_next playing White: 1227 - 818 - 2450  [0.545] 4495
...      zahak_next playing Black: 867 - 1150 - 2475  [0.468] 4492
...      White vs Black: 2377 - 1685 - 4925  [0.539] 8987
Elo difference: 4.9 +/- 4.8, LOS: 97.6 %, DrawRatio: 54.8 %
SPRT: llr 1.23 (41.9%), lbound -2.94, ubound 2.94
```