### PR TITLE
Tweak Singular Extension

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -429,7 +429,7 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 				position.UnMakeMove(hashmove, oldTag, oldEnPassant, hc)
 
 				// Search to reduced depth with a zero window a bit lower than ttScore
-				threshold := max16(nEval-2*int16(depthLeft), -CHECKMATE_EVAL)
+				threshold := max16(nEval-3*int16(depthLeft)/2, -CHECKMATE_EVAL)
 
 				e.skipMove = hashmove
 				e.skipHeight = searchHeight
@@ -457,7 +457,7 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 						e.skipMove = hashmove
 						e.innerLines[searchHeight].Recycle()
 						e.MovePickers[searchHeight] = e.TempMovePicker
-						score = e.alphaBeta((depthLeft+3)/2, searchHeight, beta-1, beta)
+						score = e.alphaBeta((depthLeft+5)/3, searchHeight, beta-1, beta)
 						e.MovePickers[searchHeight] = movePicker
 						e.innerLines[searchHeight].Recycle()
 						e.skipMove = EmptyMove


### PR DESCRIPTION
So far, had to disconnect, but will continue tweaking later:

```
Score of zahak_next vs zahak_master: 2259 - 2235 - 3591  [0.501] 8085
...      zahak_next playing White: 1337 - 990 - 1715  [0.543] 4042
...      zahak_next playing Black: 922 - 1245 - 1876  [0.460] 4043
...      White vs Black: 2582 - 1912 - 3591  [0.541] 8085
Elo difference: 1.0 +/- 5.6, LOS: 64.0 %, DrawRatio: 44.4 %
SPRT: llr -0.949 (-32.2%), lbound -2.94, ubound 2.94
```