### PR TITLE
Fix killer score use, always use searchHeight for indexing

### DIFF
--- a/search/movepicker.go
+++ b/search/movepicker.go
@@ -12,7 +12,8 @@ type MovePicker struct {
 	hashmove        Move
 	quietMoveList   *MoveList
 	captureMoveList *MoveList
-	moveOrder       int8
+	searchHeight    int8
+	depthLeft       int8
 	canUseHashMove  bool
 	isQuiescence    bool
 }
@@ -26,7 +27,8 @@ func EmptyMovePicker() *MovePicker {
 		hashmove:        EmptyMove,
 		quietMoveList:   qml,
 		captureMoveList: cml,
-		moveOrder:       0,
+		searchHeight:    0,
+		depthLeft:       0,
 		canUseHashMove:  false,
 		isQuiescence:    false,
 	}
@@ -34,10 +36,11 @@ func EmptyMovePicker() *MovePicker {
 
 }
 
-func (mp *MovePicker) RecycleWith(p *Position, e *Engine, moveOrder int8, hashmove Move, isQuiescence bool) {
+func (mp *MovePicker) RecycleWith(p *Position, e *Engine, depthLeft int8, searchHeight int8, hashmove Move, isQuiescence bool) {
 	mp.engine = e
 	mp.position = p
-	mp.moveOrder = moveOrder
+	mp.searchHeight = searchHeight
+	mp.depthLeft = depthLeft
 	mp.hashmove = hashmove
 	mp.isQuiescence = isQuiescence
 	mp.canUseHashMove = hashmove != EmptyMove
@@ -164,7 +167,8 @@ func (mp *MovePicker) scoreQuietMoves() int {
 	var highestNonHashIndex int = -1
 	var highestNonHashScore int32 = math.MinInt32
 	engine := mp.engine
-	moveOrder := mp.moveOrder
+	depthLeft := mp.depthLeft
+	searchHeight := mp.searchHeight
 	scores := mp.quietMoveList.Scores
 	moves := mp.quietMoveList.Moves
 	size := mp.quietMoveList.Size
@@ -187,7 +191,7 @@ func (mp *MovePicker) scoreQuietMoves() int {
 
 		dest := move.Destination()
 		piece := move.MovingPiece()
-		killer := engine.KillerMoveScore(move, moveOrder)
+		killer := engine.KillerMoveScore(move, searchHeight)
 		var history int32
 
 		if killer != 0 {
@@ -195,7 +199,7 @@ func (mp *MovePicker) scoreQuietMoves() int {
 			goto end
 		}
 
-		history = engine.MoveHistoryScore(piece, dest, moveOrder)
+		history = engine.MoveHistoryScore(piece, dest, depthLeft)
 		scores[i] = history
 
 	end:

--- a/search/movepicker_test.go
+++ b/search/movepicker_test.go
@@ -29,6 +29,7 @@ func TestMovepickerNextAndResetWithQuietHashmove(t *testing.T) {
 			Size:     10,
 			Next:     0,
 		},
+		1,
 		0,
 		true,
 		false,
@@ -75,6 +76,7 @@ func TestMovepickerNextAndResetWithCaptureHashmove(t *testing.T) {
 			Size:     10,
 			Next:     1,
 		},
+		1,
 		0,
 		true,
 		false,
@@ -134,6 +136,7 @@ func TestMovepickerNextAndResetWithNoHashmove(t *testing.T) {
 			Size:     10,
 			Next:     0,
 		},
+		1,
 		0,
 		false,
 		false,
@@ -180,7 +183,7 @@ func TestMovePickerNormalSearch(t *testing.T) {
 	game := FromFen(fen)
 	engine := NewEngine(NewCache(2), NewPawnCache(2), nil)
 	engine.ClearForSearch()
-	mp.RecycleWith(game.Position(), engine, 1, NewMove(A1, B1, WhiteRook, NoPiece, NoType, 0), false)
+	mp.RecycleWith(game.Position(), engine, 0, 1, NewMove(A1, B1, WhiteRook, NoPiece, NoType, 0), false)
 
 	engine.AddKillerMove(NewMove(B2, B3, WhitePawn, NoPiece, NoType, 0), 1)
 	engine.AddKillerMove(NewMove(B2, B4, WhitePawn, NoPiece, NoType, 0), 1)
@@ -266,7 +269,7 @@ func TestUpgradeMoveToHashmoveQuiet(t *testing.T) {
 	game := FromFen(fen)
 	engine := NewEngine(NewCache(2), NewPawnCache(2), nil)
 	engine.ClearForSearch()
-	mp.RecycleWith(game.Position(), engine, 1, EmptyMove, false)
+	mp.RecycleWith(game.Position(), engine, 0, 1, EmptyMove, false)
 
 	engine.AddKillerMove(NewMove(B2, B3, WhitePawn, NoPiece, NoType, 0), 1)
 	engine.AddKillerMove(NewMove(B2, B4, WhitePawn, NoPiece, NoType, 0), 1)
@@ -354,7 +357,7 @@ func TestMovePickerNormalSearchNoHashmove(t *testing.T) {
 	game := FromFen(fen)
 	engine := NewEngine(NewCache(2), NewPawnCache(2), nil)
 	engine.ClearForSearch()
-	mp.RecycleWith(game.Position(), engine, 1, EmptyMove, false)
+	mp.RecycleWith(game.Position(), engine, 0, 1, EmptyMove, false)
 
 	engine.AddKillerMove(NewMove(B2, B3, WhitePawn, NoPiece, NoType, 0), 1)
 	engine.AddKillerMove(NewMove(B2, B4, WhitePawn, NoPiece, NoType, 0), 1)
@@ -440,7 +443,7 @@ func TestMovePickerNormalSearchCaptureHashmove(t *testing.T) {
 	game := FromFen(fen)
 	engine := NewEngine(NewCache(2), NewPawnCache(2), nil)
 	engine.ClearForSearch()
-	mp.RecycleWith(game.Position(), engine, 1, NewMove(C3, D5, WhiteKnight, BlackPawn, NoType, Capture), false)
+	mp.RecycleWith(game.Position(), engine, 0, 1, NewMove(C3, D5, WhiteKnight, BlackPawn, NoType, Capture), false)
 
 	engine.AddKillerMove(NewMove(B2, B3, WhitePawn, NoPiece, NoType, 0), 1)
 	engine.AddKillerMove(NewMove(B2, B4, WhitePawn, NoPiece, NoType, 0), 1)
@@ -527,7 +530,7 @@ func TestMovePickerNormalSearchUpgradeToHashmoveCapture(t *testing.T) {
 	game := FromFen(fen)
 	engine := NewEngine(NewCache(2), NewPawnCache(2), nil)
 	engine.ClearForSearch()
-	mp.RecycleWith(game.Position(), engine, 1, EmptyMove, false)
+	mp.RecycleWith(game.Position(), engine, 0, 1, EmptyMove, false)
 
 	mp.UpgradeToPvMove(NewMove(C3, D5, WhiteKnight, BlackPawn, NoType, Capture))
 
@@ -616,7 +619,7 @@ func TestMovePickerQuiescenceSearch(t *testing.T) {
 	game := FromFen(fen)
 	engine := NewEngine(NewCache(2), NewPawnCache(2), nil)
 	engine.ClearForSearch()
-	mp.RecycleWith(game.Position(), engine, 1, EmptyMove, true)
+	mp.RecycleWith(game.Position(), engine, 0, 1, EmptyMove, true)
 
 	// all these are no-op
 	engine.AddKillerMove(NewMove(B2, B3, WhitePawn, NoPiece, NoType, 0), 1)
@@ -669,7 +672,7 @@ func TestMovePickerNormalSearchWithPromotionNoHashmove(t *testing.T) {
 	game := FromFen(fen)
 	engine := NewEngine(NewCache(2), NewPawnCache(2), nil)
 	engine.ClearForSearch()
-	mp.RecycleWith(game.Position(), engine, 1, EmptyMove, false)
+	mp.RecycleWith(game.Position(), engine, 0, 1, EmptyMove, false)
 
 	moves := []Move{
 		NewMove(H7, G8, WhitePawn, BlackKnight, Queen, Capture),
@@ -730,7 +733,7 @@ func TestMovePickerNormalSearchWithPromotionPromotionQuietHashmove(t *testing.T)
 	game := FromFen(fen)
 	engine := NewEngine(NewCache(2), NewPawnCache(2), nil)
 	engine.ClearForSearch()
-	mp.RecycleWith(game.Position(), engine, 1, NewMove(H7, H8, WhitePawn, NoPiece, Knight, 0), false)
+	mp.RecycleWith(game.Position(), engine, 0, 1, NewMove(H7, H8, WhitePawn, NoPiece, Knight, 0), false)
 
 	moves := []Move{
 		NewMove(H7, H8, WhitePawn, NoPiece, Knight, 0),
@@ -791,7 +794,7 @@ func TestMovePickerNormalSearchWithPromotionPromotionCaptureHashmove(t *testing.
 	game := FromFen(fen)
 	engine := NewEngine(NewCache(2), NewPawnCache(2), nil)
 	engine.ClearForSearch()
-	mp.RecycleWith(game.Position(), engine, 1, NewMove(H7, G8, WhitePawn, BlackKnight, Knight, Capture), false)
+	mp.RecycleWith(game.Position(), engine, 0, 1, NewMove(H7, G8, WhitePawn, BlackKnight, Knight, Capture), false)
 
 	moves := []Move{
 		NewMove(H7, G8, WhitePawn, BlackKnight, Knight, Capture),
@@ -852,7 +855,7 @@ func TestMovePickerNormalSearchWithPromotionUpgradeToPromotionQuietHashmove(t *t
 	game := FromFen(fen)
 	engine := NewEngine(NewCache(2), NewPawnCache(2), nil)
 	engine.ClearForSearch()
-	mp.RecycleWith(game.Position(), engine, 1, EmptyMove, false)
+	mp.RecycleWith(game.Position(), engine, 0, 1, EmptyMove, false)
 	mp.UpgradeToPvMove(NewMove(H7, H8, WhitePawn, NoPiece, Knight, 0))
 
 	moves := []Move{
@@ -914,7 +917,7 @@ func TestMovePickerNormalSearchWithPromotionUpgradeToPromotionCaptureHashmove(t 
 	game := FromFen(fen)
 	engine := NewEngine(NewCache(2), NewPawnCache(2), nil)
 	engine.ClearForSearch()
-	mp.RecycleWith(game.Position(), engine, 1, EmptyMove, false)
+	mp.RecycleWith(game.Position(), engine, 0, 1, EmptyMove, false)
 	mp.UpgradeToPvMove(NewMove(H7, G8, WhitePawn, BlackKnight, Knight, Capture))
 
 	moves := []Move{

--- a/search/quiescence.go
+++ b/search/quiescence.go
@@ -78,7 +78,7 @@ func (e *Engine) quiescence(alpha int16, beta int16, searchHeight int8) int16 {
 
 	var isInCheck = e.Position.IsInCheck()
 	movePicker := e.MovePickers[searchHeight]
-	movePicker.RecycleWith(position, e, -1, EmptyMove, !isInCheck)
+	movePicker.RecycleWith(position, e, -1, searchHeight, EmptyMove, !isInCheck)
 
 	bestscore := standPat
 	noisyMoves := -1

--- a/search/types.go
+++ b/search/types.go
@@ -266,14 +266,14 @@ func (e *Engine) ClearForSearch() {
 	e.pred.Clear()
 }
 
-func (e *Engine) KillerMoveScore(move Move, depthLeft int8) int32 {
-	if move == EmptyMove || depthLeft < 0 || e.killerMoves[depthLeft] == nil {
+func (e *Engine) KillerMoveScore(move Move, searchHeight int8) int32 {
+	if move == EmptyMove || searchHeight < 0 || e.killerMoves[searchHeight] == nil {
 		return 0
 	}
-	if e.killerMoves[depthLeft][0] == move {
+	if e.killerMoves[searchHeight][0] == move {
 		return 90_000_000
 	}
-	if e.killerMoves[depthLeft][1] == move {
+	if e.killerMoves[searchHeight][1] == move {
 		return 80_000_000
 	}
 	return 0
@@ -286,9 +286,9 @@ func historyBonus(current int32, bonus int32) int32 {
 func (e *Engine) AddHistory(move Move, movingPiece Piece, destination Square, depthLeft int8, searchHeight int8, quietMovesCounter int) {
 	if depthLeft >= 0 && move.PromoType() == NoType && !move.IsCapture() {
 		e.info.killerCounter += 1
-		if e.killerMoves[depthLeft][0] != move {
-			e.killerMoves[depthLeft][1] = e.killerMoves[depthLeft][0]
-			e.killerMoves[depthLeft][0] = move
+		if e.killerMoves[searchHeight][0] != move {
+			e.killerMoves[searchHeight][1] = e.killerMoves[searchHeight][0]
+			e.killerMoves[searchHeight][0] = move
 		}
 
 		if depthLeft <= 1 {
@@ -325,11 +325,11 @@ func (e *Engine) RemoveMoveHistory(killerMove Move, quietMovesCounter int, depth
 	}
 }
 
-func (e *Engine) AddKillerMove(move Move, depthLeft int8) {
+func (e *Engine) AddKillerMove(move Move, searchHeight int8) {
 	if !move.IsCapture() {
 		e.info.killerCounter += 1
-		e.killerMoves[depthLeft][1] = e.killerMoves[depthLeft][0]
-		e.killerMoves[depthLeft][0] = move
+		e.killerMoves[searchHeight][1] = e.killerMoves[searchHeight][0]
+		e.killerMoves[searchHeight][0] = move
 	}
 }
 


### PR DESCRIPTION
```
Score of zahak_next vs zahak_master: 654 - 516 - 1422  [0.527] 2592
...      zahak_next playing White: 391 - 204 - 701  [0.572] 1296
...      zahak_next playing Black: 263 - 312 - 721  [0.481] 1296
...      White vs Black: 703 - 467 - 1422  [0.546] 2592
Elo difference: 18.5 +/- 9.0, LOS: 100.0 %, DrawRatio: 54.9 %
SPRT: llr 2.96 (100.7%), lbound -2.94, ubound 2.94 - H1 was accepted
Finished match
```