### PR TITLE
Countermove for move ordering

### DIFF
--- a/search/movepicker_test.go
+++ b/search/movepicker_test.go
@@ -31,6 +31,7 @@ func TestMovepickerNextAndResetWithQuietHashmove(t *testing.T) {
 		},
 		1,
 		0,
+		EmptyMove,
 		true,
 		false,
 	}
@@ -78,6 +79,7 @@ func TestMovepickerNextAndResetWithCaptureHashmove(t *testing.T) {
 		},
 		1,
 		0,
+		EmptyMove,
 		true,
 		false,
 	}
@@ -138,6 +140,7 @@ func TestMovepickerNextAndResetWithNoHashmove(t *testing.T) {
 		},
 		1,
 		0,
+		EmptyMove,
 		false,
 		false,
 	}

--- a/search/search.go
+++ b/search/search.go
@@ -487,7 +487,7 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 						if !firstLayerOfSingularity {
 							e.TranspositionTable.Set(hash, hashmove, bestscore, depthLeft, LowerBound, e.Ply)
 						}
-						e.AddHistory(hashmove, hashmove.MovingPiece(), hashmove.Destination(), depthLeft, searchHeight, legalQuiteMove)
+						e.AddHistory(hashmove, currentMove, hashmove.MovingPiece(), hashmove.Destination(), depthLeft, searchHeight, legalQuiteMove)
 					}
 					return bestscore
 				}
@@ -635,7 +635,7 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 						if !firstLayerOfSingularity {
 							e.TranspositionTable.Set(hash, move, score, depthLeft, LowerBound, e.Ply)
 						}
-						e.AddHistory(move, move.MovingPiece(), move.Destination(), depthLeft, searchHeight, legalQuiteMove)
+						e.AddHistory(move, currentMove, move.MovingPiece(), move.Destination(), depthLeft, searchHeight, legalQuiteMove)
 					}
 					return score
 				}


### PR DESCRIPTION
```
Score of zahak_next vs zahak_master: 4014 - 3750 - 5966  [0.510] 13730
...      zahak_next playing White: 2202 - 1653 - 3010  [0.540] 6865
...      zahak_next playing Black: 1812 - 2097 - 2956  [0.479] 6865
...      White vs Black: 4299 - 3465 - 5966  [0.530] 13730
Elo difference: 6.7 +/- 4.4, LOS: 99.9 %, DrawRatio: 43.5 %
SPRT: llr 2.96 (100.6%), lbound -2.94, ubound 2.94 - H1 was accepted
Finished match
```