### PR TITLE
Re-tune eval terms with Lichess data

### DIFF
--- a/engine/eval_terms.go
+++ b/engine/eval_terms.go
@@ -4,193 +4,193 @@ package engine
 // Middle-game
 var EarlyPawnPst = [64]int16{
 	0, 0, 0, 0, 0, 0, 0, 0,
-	89, 126, 68, 110, 93, 132, 14, -38,
-	-11, -16, 19, 20, 63, 80, 17, -16,
-	-24, -9, -9, 15, 14, 13, 0, -26,
-	-39, -32, -16, 0, 5, -1, -14, -37,
-	-34, -34, -18, -18, -6, -10, 4, -23,
-	-44, -30, -34, -27, -26, 11, 10, -30,
+	67, 69, 81, 83, 66, 66, -19, -59,
+	-11, -7, 27, 27, 40, 72, 26, -1,
+	-28, -17, -9, -2, 18, 15, -1, -14,
+	-35, -28, -15, 2, 5, 1, -12, -21,
+	-37, -31, -20, -12, -2, -16, -5, -25,
+	-39, -35, -30, -28, -18, -9, -1, -35,
 	0, 0, 0, 0, 0, 0, 0, 0,
 }
 
 var EarlyKnightPst = [64]int16{
-	-187, -81, -44, -40, 63, -112, -19, -122,
-	-63, -24, 96, 40, 36, 87, 17, 0,
-	-26, 84, 59, 72, 103, 148, 84, 66,
-	25, 50, 42, 67, 40, 86, 38, 49,
-	27, 49, 51, 40, 57, 44, 47, 28,
-	19, 30, 43, 49, 62, 52, 67, 25,
-	15, -9, 32, 42, 44, 55, 31, 34,
-	-86, 26, -12, 3, 36, 19, 29, 23,
+	-174, -71, -32, -49, 34, -73, -1, -112,
+	-21, 4, 35, 56, 19, 105, 16, 9,
+	13, 55, 49, 53, 95, 116, 62, 43,
+	34, 45, 57, 67, 39, 74, 37, 57,
+	26, 35, 47, 42, 54, 42, 45, 32,
+	2, 29, 39, 47, 57, 44, 49, 21,
+	5, 10, 27, 45, 42, 42, 35, 34,
+	-44, 10, 5, 19, 20, 36, 13, -13,
 }
 
 var EarlyBishopPst = [64]int16{
-	-13, 30, -92, -52, -30, -35, 14, 16,
-	2, 44, 10, -6, 49, 75, 36, -25,
-	19, 64, 74, 57, 58, 73, 46, 22,
-	32, 34, 36, 68, 54, 51, 32, 21,
-	33, 47, 40, 57, 62, 38, 46, 39,
-	32, 57, 54, 48, 55, 74, 58, 41,
-	45, 63, 56, 44, 54, 64, 81, 46,
-	5, 39, 36, 26, 35, 35, 2, 18,
+	-23, -20, -43, -57, -51, -26, -1, -36,
+	2, 20, 14, 12, 19, 21, 7, 20,
+	38, 45, 41, 50, 39, 72, 47, 53,
+	25, 40, 40, 52, 59, 41, 37, 11,
+	30, 26, 36, 55, 51, 38, 33, 38,
+	31, 50, 52, 49, 48, 58, 54, 44,
+	45, 52, 60, 39, 51, 59, 69, 53,
+	33, 53, 35, 36, 38, 29, 36, 42,
 }
 
 var EarlyRookPst = [64]int16{
-	-4, 13, -18, 21, 23, -22, 1, -11,
-	2, -8, 30, 29, 56, 58, -4, 20,
-	-39, -18, -10, -9, -31, 21, 40, -22,
-	-44, -31, -20, -2, -19, 14, -23, -36,
-	-53, -51, -35, -30, -19, -32, -6, -43,
-	-55, -35, -32, -33, -21, -10, -17, -38,
-	-48, -26, -34, -25, -14, 4, -15, -74,
-	-21, -20, -12, -3, -1, 1, -38, -20,
+	-16, -20, -7, -4, -2, -8, 10, 9,
+	-21, -29, -5, 8, 0, 36, 14, 41,
+	-35, -11, -20, -19, 7, 30, 57, 11,
+	-35, -27, -21, -14, -26, -5, -9, -18,
+	-41, -43, -41, -32, -35, -40, -6, -22,
+	-42, -37, -36, -31, -28, -19, 4, -13,
+	-34, -37, -30, -28, -21, -11, -2, -28,
+	-22, -21, -19, -11, -9, -8, -3, -25,
 }
 
 var EarlyQueenPst = [64]int16{
-	-54, -29, -12, -12, 46, 43, 39, 19,
-	-29, -56, -23, -25, -71, 29, -9, 29,
-	-13, -17, -9, -45, -9, 27, 5, 20,
-	-35, -31, -35, -46, -32, -24, -34, -22,
-	-7, -40, -21, -23, -24, -18, -19, -16,
-	-22, 12, -10, 1, -4, -1, 4, -2,
-	-20, 3, 21, 18, 25, 29, 12, 22,
-	16, 3, 16, 30, 3, -4, -5, -32,
+	-40, -41, -9, 0, 14, 43, 38, -13,
+	-15, -34, -33, -27, -49, 8, -22, 32,
+	3, 3, -2, -14, -12, 20, 19, 34,
+	-16, -3, -17, -21, -26, -14, -16, -5,
+	1, -20, -10, -7, -10, -10, -6, 4,
+	-10, 11, 2, 2, 8, 4, 17, 5,
+	4, 14, 19, 23, 23, 26, 27, 37,
+	19, 5, 12, 21, 15, 7, 13, 11,
 }
 
 var EarlyKingPst = [64]int16{
-	-52, 116, 111, 56, -51, -18, 43, 46,
-	108, 49, 26, 79, 23, 16, -14, -72,
-	35, 49, 64, 17, 33, 70, 74, -13,
-	-15, -4, 20, -18, -22, -21, -19, -65,
-	-46, 18, -35, -72, -75, -52, -62, -85,
-	-12, -12, -28, -57, -56, -47, -20, -40,
-	17, 22, -9, -59, -35, -16, 12, 17,
-	-7, 37, 14, -59, -10, -35, 28, 24,
+	-70, 140, 133, 78, -17, -14, 44, 17,
+	97, 72, 64, 71, 38, 26, 9, -64,
+	-7, 55, 59, 22, 42, 50, 56, -36,
+	-48, -11, -21, -44, -37, -41, -62, -99,
+	-71, -39, -36, -70, -80, -69, -92, -124,
+	-25, -12, -35, -53, -47, -43, -23, -46,
+	37, 11, -6, -16, -14, -10, 14, 16,
+	20, 46, 17, -47, -24, -38, 21, 33,
 }
 
 // Endgame
 var LatePawnPst = [64]int16{
 	0, 0, 0, 0, 0, 0, 0, 0,
-	173, 146, 130, 100, 111, 100, 151, 191,
-	83, 80, 55, 28, 9, 18, 57, 67,
-	20, 1, -11, -31, -21, -16, -1, 8,
-	21, 10, -2, -10, -11, -6, -2, 6,
-	2, -3, -12, -10, -8, -10, -18, -14,
-	14, -4, 2, -1, 2, -13, -18, -13,
+	131, 112, 99, 58, 58, 75, 110, 123,
+	73, 64, 34, 4, -3, 12, 45, 50,
+	26, 7, -6, -22, -25, -16, -1, 6,
+	16, 2, -7, -8, -11, -8, -2, 0,
+	7, -2, -9, -11, -6, -10, -13, -8,
+	8, -3, -5, -9, 1, -11, -18, -8,
 	0, 0, 0, 0, 0, 0, 0, 0,
 }
 
 var LateKnightPst = [64]int16{
-	-35, -42, -13, -35, -40, -27, -70, -89,
-	-25, -11, -45, -11, -25, -49, -31, -54,
-	-31, -35, -8, -13, -29, -34, -32, -55,
-	-21, -4, 10, 4, 6, -3, -1, -26,
-	-25, -19, 1, 15, 3, 4, -4, -23,
-	-29, -9, -15, 2, -5, -20, -33, -26,
-	-39, -20, -17, -13, -13, -26, -27, -52,
-	-13, -57, -24, -12, -28, -22, -60, -73,
+	-45, -15, -13, -6, -25, -34, -43, -83,
+	-32, -11, -22, -21, -24, -46, -25, -46,
+	-20, -12, 0, -11, -35, -29, -14, -29,
+	-4, 0, 5, -7, 0, 7, 6, -21,
+	-17, -3, -1, 11, 8, -2, -5, -18,
+	-15, -10, -16, 6, -1, -17, -19, -20,
+	-13, -14, -5, -9, -13, -15, -11, -10,
+	14, -41, -6, -10, -12, -25, -37, -35,
 }
 
 var LateBishopPst = [64]int16{
-	-22, -35, -14, -16, -14, -18, -24, -34,
-	-17, -24, -12, -21, -22, -30, -24, -20,
-	-11, -24, -25, -26, -25, -22, -15, -9,
-	-17, -5, -6, -10, -8, -12, -17, -8,
-	-21, -16, -6, -4, -19, -10, -24, -21,
-	-20, -15, -6, -8, -6, -21, -16, -22,
-	-26, -31, -20, -14, -13, -21, -30, -44,
-	-26, -17, -26, -13, -17, -22, -11, -25,
+	-16, 1, 0, -7, -7, -17, -30, -23,
+	-31, -27, -19, -13, -29, -30, -29, -30,
+	-16, -18, -25, -31, -29, -23, -14, -17,
+	-9, -9, -15, -10, -21, -15, -16, -4,
+	-19, -17, -14, -15, -23, -21, -20, -35,
+	-30, -11, -11, -14, -6, -22, -26, -25,
+	-25, -29, -32, -19, -20, -29, -26, -49,
+	-23, -28, -36, -19, -15, -20, -33, -42,
 }
 
 var LateRookPst = [64]int16{
-	11, 4, 15, 5, 7, 14, 8, 8,
-	9, 14, 3, 3, -16, -7, 11, 4,
-	13, 10, 3, 5, 3, -8, -9, 1,
-	14, 7, 15, -1, 4, 2, 1, 13,
-	15, 18, 16, 10, 3, 5, -3, 3,
-	13, 10, 5, 9, 1, -6, 3, -1,
-	10, 4, 11, 13, 0, -5, -4, 15,
-	6, 10, 9, 1, -2, -1, 10, -13,
+	9, 13, 14, 14, 5, 22, 5, 8,
+	13, 29, 28, 20, 18, 10, 14, -4,
+	14, 12, 18, 8, -4, -2, -12, -12,
+	18, 16, 15, 7, 3, 0, 5, 3,
+	16, 9, 12, 13, 10, 16, -9, -4,
+	15, 5, 13, 10, 6, -1, -18, -11,
+	11, 9, 13, 11, 7, -4, -9, 2,
+	12, 3, 7, -5, -5, -1, -4, 4,
 }
 
 var LateQueenPst = [64]int16{
-	36, 65, 59, 56, 42, 35, 27, 61,
-	13, 50, 58, 73, 101, 45, 68, 42,
-	6, 24, 18, 89, 71, 51, 58, 44,
-	48, 52, 46, 74, 81, 65, 102, 74,
-	4, 62, 49, 70, 58, 57, 71, 58,
-	32, -20, 37, 26, 36, 45, 56, 48,
-	3, -1, -14, 5, 8, 5, -9, -9,
-	-12, -13, -5, -23, 23, -2, 3, -15,
+	50, 56, 58, 49, 51, 50, 47, 43,
+	20, 68, 87, 80, 119, 77, 87, 56,
+	22, 35, 56, 76, 89, 87, 89, 48,
+	57, 58, 64, 92, 92, 74, 104, 71,
+	25, 71, 48, 73, 65, 65, 68, 58,
+	40, 9, 49, 35, 41, 55, 44, 35,
+	18, 9, 5, 19, 18, 9, -2, -18,
+	2, 9, 16, -2, 15, 12, 15, 17,
 }
 
 var LateKingPst = [64]int16{
-	-76, -61, -41, -34, -6, 16, -6, -18,
-	-38, -4, -1, -7, 2, 25, 13, 19,
-	-1, 1, 1, 3, 1, 25, 23, 9,
-	-13, 10, 12, 20, 18, 25, 17, 8,
-	-17, -17, 18, 27, 28, 20, 6, -3,
-	-21, -9, 9, 22, 23, 16, 0, -4,
-	-33, -20, 5, 13, 12, 5, -12, -24,
-	-57, -47, -23, 1, -24, -4, -37, -57,
+	-141, -79, -41, -15, 31, 12, -29, -74,
+	-17, 20, 38, 25, 41, 47, 46, 14,
+	-4, 24, 31, 38, 33, 32, 33, 7,
+	-6, 17, 27, 38, 36, 32, 22, 7,
+	-6, 1, 18, 30, 26, 14, 9, 2,
+	-23, -11, 4, 15, 14, 2, -11, -8,
+	-26, -13, -2, -2, -1, -5, -20, -25,
+	-38, -49, -31, -6, -28, -7, -38, -56,
 }
 
-var MiddlegameBackwardPawnPenalty int16 = 10
-var EndgameBackwardPawnPenalty int16 = 4
-var MiddlegameIsolatedPawnPenalty int16 = 15
+var MiddlegameBackwardPawnPenalty int16 = 12
+var EndgameBackwardPawnPenalty int16 = 7
+var MiddlegameIsolatedPawnPenalty int16 = 14
 var EndgameIsolatedPawnPenalty int16 = 6
-var MiddlegameDoublePawnPenalty int16 = 2
-var EndgameDoublePawnPenalty int16 = 25
+var MiddlegameDoublePawnPenalty int16 = 7
+var EndgameDoublePawnPenalty int16 = 23
 var MiddlegamePassedPawnAward int16 = 0
-var EndgamePassedPawnAward int16 = 10
-var MiddlegameAdvancedPassedPawnAward int16 = 11
-var EndgameAdvancedPassedPawnAward int16 = 65
-var MiddlegameCandidatePassedPawnAward int16 = 40
-var EndgameCandidatePassedPawnAward int16 = 51
-var MiddlegameRookOpenFileAward int16 = 47
-var EndgameRookOpenFileAward int16 = 0
-var MiddlegameRookSemiOpenFileAward int16 = 13
-var EndgameRookSemiOpenFileAward int16 = 19
-var MiddlegameVeritcalDoubleRookAward int16 = 11
-var EndgameVeritcalDoubleRookAward int16 = 11
-var MiddlegameHorizontalDoubleRookAward int16 = 28
-var EndgameHorizontalDoubleRookAward int16 = 12
-var MiddlegamePawnFactorCoeff int16 = 0
+var EndgamePassedPawnAward int16 = 13
+var MiddlegameAdvancedPassedPawnAward int16 = 17
+var EndgameAdvancedPassedPawnAward int16 = 62
+var MiddlegameCandidatePassedPawnAward int16 = 53
+var EndgameCandidatePassedPawnAward int16 = 52
+var MiddlegameRookOpenFileAward int16 = 37
+var EndgameRookOpenFileAward int16 = 2
+var MiddlegameRookSemiOpenFileAward int16 = 15
+var EndgameRookSemiOpenFileAward int16 = 10
+var MiddlegameVeritcalDoubleRookAward int16 = 0
+var EndgameVeritcalDoubleRookAward int16 = 19
+var MiddlegameHorizontalDoubleRookAward int16 = 22
+var EndgameHorizontalDoubleRookAward int16 = 7
+var MiddlegamePawnFactorCoeff int16 = 1
 var EndgamePawnFactorCoeff int16 = 1
-var MiddlegamePawnSquareControlCoeff int16 = 6
-var EndgamePawnSquareControlCoeff int16 = 4
-var MiddlegameMinorMobilityFactorCoeff int16 = 5
-var EndgameMinorMobilityFactorCoeff int16 = 1
-var MiddlegameMinorAggressivityFactorCoeff int16 = 4
-var EndgameMinorAggressivityFactorCoeff int16 = 3
+var MiddlegamePawnSquareControlCoeff int16 = 1
+var EndgamePawnSquareControlCoeff int16 = 7
+var MiddlegameMinorMobilityFactorCoeff int16 = 3
+var EndgameMinorMobilityFactorCoeff int16 = 3
+var MiddlegameMinorAggressivityFactorCoeff int16 = 5
+var EndgameMinorAggressivityFactorCoeff int16 = 7
 var MiddlegameMajorMobilityFactorCoeff int16 = 3
-var EndgameMajorMobilityFactorCoeff int16 = 3
+var EndgameMajorMobilityFactorCoeff int16 = 4
 var MiddlegameMajorAggressivityFactorCoeff int16 = 0
-var EndgameMajorAggressivityFactorCoeff int16 = 5
-var MiddlegameInnerPawnToKingAttackCoeff int16 = 2
+var EndgameMajorAggressivityFactorCoeff int16 = 6
+var MiddlegameInnerPawnToKingAttackCoeff int16 = 6
 var EndgameInnerPawnToKingAttackCoeff int16 = 0
-var MiddlegameOuterPawnToKingAttackCoeff int16 = 4
-var EndgameOuterPawnToKingAttackCoeff int16 = 1
-var MiddlegameInnerMinorToKingAttackCoeff int16 = 17
+var MiddlegameOuterPawnToKingAttackCoeff int16 = 1
+var EndgameOuterPawnToKingAttackCoeff int16 = 7
+var MiddlegameInnerMinorToKingAttackCoeff int16 = 20
 var EndgameInnerMinorToKingAttackCoeff int16 = 0
-var MiddlegameOuterMinorToKingAttackCoeff int16 = 10
-var EndgameOuterMinorToKingAttackCoeff int16 = 2
-var MiddlegameInnerMajorToKingAttackCoeff int16 = 15
+var MiddlegameOuterMinorToKingAttackCoeff int16 = 11
+var EndgameOuterMinorToKingAttackCoeff int16 = 3
+var MiddlegameInnerMajorToKingAttackCoeff int16 = 19
 var EndgameInnerMajorToKingAttackCoeff int16 = 0
-var MiddlegameOuterMajorToKingAttackCoeff int16 = 11
-var EndgameOuterMajorToKingAttackCoeff int16 = 3
-var MiddlegamePawnShieldPenalty int16 = 8
+var MiddlegameOuterMajorToKingAttackCoeff int16 = 6
+var EndgameOuterMajorToKingAttackCoeff int16 = 4
+var MiddlegamePawnShieldPenalty int16 = 16
 var EndgamePawnShieldPenalty int16 = 10
-var MiddlegameNotCastlingPenalty int16 = 33
-var EndgameNotCastlingPenalty int16 = 6
-var MiddlegameKingZoneOpenFilePenalty int16 = 38
+var MiddlegameNotCastlingPenalty int16 = 55
+var EndgameNotCastlingPenalty int16 = 0
+var MiddlegameKingZoneOpenFilePenalty int16 = 60
 var EndgameKingZoneOpenFilePenalty int16 = 0
-var MiddlegameKingZoneMissingPawnPenalty int16 = 15
+var MiddlegameKingZoneMissingPawnPenalty int16 = 27
 var EndgameKingZoneMissingPawnPenalty int16 = 0
-var MiddlegameKnightOutpostAward int16 = 17
-var EndgameKnightOutpostAward int16 = 23
-var MiddlegameBishopPairAward int16 = 28
-var EndgameBishopPairAward int16 = 44
+var MiddlegameKnightOutpostAward int16 = 16
+var EndgameKnightOutpostAward int16 = 30
+var MiddlegameBishopPairAward int16 = 23
+var EndgameBishopPairAward int16 = 50
 
 var Flip = [64]int16{
 	56, 57, 58, 59, 60, 61, 62, 63,

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -164,7 +164,7 @@ func TestReubenFineBasicChessEndingsPosition70(t *testing.T) {
 	r.AddTimeManager(NewTimeManager(time.Now(), 400_000, true, 0, 0, false))
 	e := r.Engines[0]
 	e.Position = game.Position()
-	e.Search(25)
+	e.Search(30)
 	expected := NewMove(A1, B1, WhiteKing, NoPiece, NoType, 0)
 	mv := r.Move()
 	mvStr := mv.ToString()

--- a/tuning/texel_tuning.go
+++ b/tuning/texel_tuning.go
@@ -446,21 +446,34 @@ func loadPositions(path string, actionFn func(string)) {
 }
 
 func parseLine(line string) (string, float64) {
-	fields := strings.Fields(line)
-	fen := strings.Join(fields[:4], " ")
-	fen = fmt.Sprintf("%s 0 1", fen)
-
-	outcomeStr := strings.Trim(fields[5], "\";")
+	fields := strings.Split(line, "|")
+	fen := strings.TrimSpace(fields[0])
+	res := strings.TrimSpace(fields[1])
 	var outcome float64
-	if outcomeStr == "1/2-1/2" {
-		outcome = 0.5
-	} else if outcomeStr == "1-0" {
-		outcome = 1.0
-	} else if outcomeStr == "0-1" {
-		outcome = 0.0
+	if res == "Black" {
+		outcome = 0
+	} else if res == "White" {
+		outcome = 1
 	} else {
-		panic(fmt.Sprintf("Unexpected output %s", outcomeStr))
+		outcome = 0.5
 	}
+	return fen, outcome
+	// fields := strings.Fields(line)
+	// fen := strings.Join(fields[:4], " ")
+	// fen = fmt.Sprintf("%s 0 1", fen)
+	//
+	// outcomeStr := strings.Trim(fields[5], "\";")
+	// var outcome float64
+	// if outcomeStr == "1/2-1/2" {
+	// 	outcome = 0.5
+	// } else if outcomeStr == "1-0" {
+	// 	outcome = 1.0
+	// } else if outcomeStr == "0-1" {
+	// 	outcome = 0.0
+	// } else {
+	// 	panic(fmt.Sprintf("Unexpected output %s", outcomeStr))
+	// }
+
 	//
 	// fen := strings.Trim(strings.Join(fields[:6], " "), ";")
 	//
@@ -508,7 +521,9 @@ func Tune(path string, toExclude map[int]bool) {
 	})
 
 	fmt.Printf("%d positions loaded\n", len(testPositions))
+	// Optimal K is 1.640449
 	K := findK()
+
 	fmt.Printf("Optimal K is %f\n", K)
 	optimalGuesses := localOptimize(initialGuesses, K)
 	// tuningVars := make([]Parameter, len(initialGuesses))


### PR DESCRIPTION
```
Score of zahak_next vs zahak_master: 1388 - 1190 - 1456  [0.525] 4034
...      zahak_next playing White: 732 - 537 - 747  [0.548] 2016
...      zahak_next playing Black: 656 - 653 - 709  [0.501] 2018
...      White vs Black: 1385 - 1193 - 1456  [0.524] 4034
Elo difference: 17.1 +/- 8.6, LOS: 100.0 %, DrawRatio: 36.1 %
SPRT: llr 2.94 (100.0%), lbound -2.94, ubound 2.94 - H1 was accepted
Finished match
```