### PR TITLE
Reward passed pawns based on their ranks

### DIFF
--- a/engine/eval_terms.go
+++ b/engine/eval_terms.go
@@ -4,193 +4,197 @@ package engine
 // Middle-game
 var EarlyPawnPst = [64]int16{
 	0, 0, 0, 0, 0, 0, 0, 0,
-	67, 69, 81, 83, 66, 66, -19, -59,
-	-11, -7, 27, 27, 40, 72, 26, -1,
-	-28, -17, -9, -2, 18, 15, -1, -14,
-	-35, -28, -15, 2, 5, 1, -12, -21,
-	-37, -31, -20, -12, -2, -16, -5, -25,
-	-39, -35, -30, -28, -18, -9, -1, -35,
+	77, 55, 89, 87, 81, 32, -20, -53,
+	-17, -16, 16, 11, 24, 61, 17, -10,
+	-32, -24, -13, -8, 12, 8, -7, -18,
+	-36, -32, -17, 0, 3, -3, -14, -23,
+	-39, -35, -21, -15, -4, -20, -8, -28,
+	-42, -38, -32, -30, -20, -15, -4, -39,
 	0, 0, 0, 0, 0, 0, 0, 0,
 }
 
 var EarlyKnightPst = [64]int16{
-	-174, -71, -32, -49, 34, -73, -1, -112,
-	-21, 4, 35, 56, 19, 105, 16, 9,
-	13, 55, 49, 53, 95, 116, 62, 43,
-	34, 45, 57, 67, 39, 74, 37, 57,
-	26, 35, 47, 42, 54, 42, 45, 32,
-	2, 29, 39, 47, 57, 44, 49, 21,
-	5, 10, 27, 45, 42, 42, 35, 34,
-	-44, 10, 5, 19, 20, 36, 13, -13,
+	-180, -74, -35, -57, 25, -70, -12, -112,
+	-13, 4, 26, 57, 18, 104, 10, 8,
+	19, 52, 45, 50, 93, 108, 61, 37,
+	32, 40, 55, 63, 37, 68, 34, 53,
+	23, 34, 45, 39, 51, 38, 42, 28,
+	2, 26, 35, 44, 52, 40, 46, 19,
+	2, 9, 26, 42, 38, 38, 33, 29,
+	-35, 7, 4, 17, 17, 33, 10, -18,
 }
 
 var EarlyBishopPst = [64]int16{
-	-23, -20, -43, -57, -51, -26, -1, -36,
-	2, 20, 14, 12, 19, 21, 7, 20,
-	38, 45, 41, 50, 39, 72, 47, 53,
-	25, 40, 40, 52, 59, 41, 37, 11,
-	30, 26, 36, 55, 51, 38, 33, 38,
-	31, 50, 52, 49, 48, 58, 54, 44,
-	45, 52, 60, 39, 51, 59, 69, 53,
-	33, 53, 35, 36, 38, 29, 36, 42,
+	-29, -42, -22, -64, -59, -27, -3, -50,
+	3, 15, 12, 13, 13, 15, 2, 25,
+	38, 43, 40, 48, 35, 70, 46, 54,
+	23, 37, 39, 50, 54, 39, 35, 10,
+	27, 23, 34, 53, 49, 36, 32, 36,
+	30, 47, 50, 46, 46, 54, 52, 42,
+	42, 50, 57, 37, 49, 57, 67, 52,
+	37, 52, 33, 35, 37, 27, 35, 46,
 }
 
 var EarlyRookPst = [64]int16{
-	-16, -20, -7, -4, -2, -8, 10, 9,
-	-21, -29, -5, 8, 0, 36, 14, 41,
-	-35, -11, -20, -19, 7, 30, 57, 11,
-	-35, -27, -21, -14, -26, -5, -9, -18,
-	-41, -43, -41, -32, -35, -40, -6, -22,
-	-42, -37, -36, -31, -28, -19, 4, -13,
-	-34, -37, -30, -28, -21, -11, -2, -28,
-	-22, -21, -19, -11, -9, -8, -3, -25,
+	-17, -25, -11, -10, -13, -1, 11, 15,
+	-24, -28, -8, 5, -8, 33, 20, 48,
+	-37, -11, -20, -20, 8, 31, 58, 17,
+	-32, -28, -21, -16, -25, -6, -3, -17,
+	-42, -44, -41, -31, -35, -39, -5, -23,
+	-43, -39, -35, -32, -28, -20, 6, -10,
+	-33, -37, -30, -28, -21, -12, -2, -25,
+	-23, -21, -19, -12, -9, -9, 2, -24,
 }
 
 var EarlyQueenPst = [64]int16{
-	-40, -41, -9, 0, 14, 43, 38, -13,
-	-15, -34, -33, -27, -49, 8, -22, 32,
-	3, 3, -2, -14, -12, 20, 19, 34,
-	-16, -3, -17, -21, -26, -14, -16, -5,
-	1, -20, -10, -7, -10, -10, -6, 4,
-	-10, 11, 2, 2, 8, 4, 17, 5,
-	4, 14, 19, 23, 23, 26, 27, 37,
-	19, 5, 12, 21, 15, 7, 13, 11,
+	-36, -35, -6, 7, 13, 48, 39, -11,
+	-12, -27, -31, -22, -43, 3, -24, 34,
+	8, 9, -1, -6, -9, 19, 24, 41,
+	-10, 1, -14, -14, -21, -9, -10, 1,
+	2, -15, -7, -3, -4, -7, -1, 8,
+	-9, 11, 4, 4, 10, 6, 21, 10,
+	5, 16, 20, 23, 24, 27, 29, 40,
+	22, 6, 14, 21, 18, 9, 13, 17,
 }
 
 var EarlyKingPst = [64]int16{
-	-70, 140, 133, 78, -17, -14, 44, 17,
-	97, 72, 64, 71, 38, 26, 9, -64,
-	-7, 55, 59, 22, 42, 50, 56, -36,
-	-48, -11, -21, -44, -37, -41, -62, -99,
-	-71, -39, -36, -70, -80, -69, -92, -124,
-	-25, -12, -35, -53, -47, -43, -23, -46,
-	37, 11, -6, -16, -14, -10, 14, 16,
-	20, 46, 17, -47, -24, -38, 21, 33,
+	-48, 175, 159, 77, -8, -22, 46, 41,
+	68, 79, 66, 47, 14, 28, 12, -53,
+	-38, 52, 44, -16, 16, 37, 49, -50,
+	-75, -21, -38, -67, -48, -67, -90, -113,
+	-76, -63, -31, -66, -76, -74, -98, -141,
+	-24, -8, -33, -48, -45, -38, -19, -42,
+	34, 8, -8, -6, -6, -11, 14, 16,
+	20, 43, 15, -43, -24, -39, 21, 33,
 }
 
 // Endgame
 var LatePawnPst = [64]int16{
 	0, 0, 0, 0, 0, 0, 0, 0,
-	131, 112, 99, 58, 58, 75, 110, 123,
-	73, 64, 34, 4, -3, 12, 45, 50,
-	26, 7, -6, -22, -25, -16, -1, 6,
-	16, 2, -7, -8, -11, -8, -2, 0,
-	7, -2, -9, -11, -6, -10, -13, -8,
-	8, -3, -5, -9, 1, -11, -18, -8,
+	144, 131, 110, 71, 66, 103, 124, 137,
+	48, 40, 6, -26, -30, -4, 22, 33,
+	26, 9, -7, -18, -23, -14, 1, 6,
+	8, -3, -14, -17, -18, -13, -7, -6,
+	5, -4, -15, -13, -9, -13, -15, -11,
+	6, -6, -8, -11, -4, -11, -20, -9,
 	0, 0, 0, 0, 0, 0, 0, 0,
 }
 
 var LateKnightPst = [64]int16{
-	-45, -15, -13, -6, -25, -34, -43, -83,
-	-32, -11, -22, -21, -24, -46, -25, -46,
-	-20, -12, 0, -11, -35, -29, -14, -29,
-	-4, 0, 5, -7, 0, 7, 6, -21,
-	-17, -3, -1, 11, 8, -2, -5, -18,
-	-15, -10, -16, 6, -1, -17, -19, -20,
-	-13, -14, -5, -9, -13, -15, -11, -10,
-	14, -41, -6, -10, -12, -25, -37, -35,
+	-48, -18, -15, -5, -24, -40, -44, -90,
+	-36, -13, -15, -24, -25, -47, -23, -44,
+	-26, -12, 0, -10, -35, -26, -18, -27,
+	-6, 0, 3, -8, -3, 8, 5, -22,
+	-16, -4, -2, 11, 8, -2, -5, -18,
+	-17, -7, -15, 4, 0, -16, -19, -21,
+	-12, -16, -8, -10, -13, -15, -12, -5,
+	0, -39, -9, -14, -11, -26, -35, -29,
 }
 
 var LateBishopPst = [64]int16{
-	-16, 1, 0, -7, -7, -17, -30, -23,
-	-31, -27, -19, -13, -29, -30, -29, -30,
-	-16, -18, -25, -31, -29, -23, -14, -17,
-	-9, -9, -15, -10, -21, -15, -16, -4,
-	-19, -17, -14, -15, -23, -21, -20, -35,
-	-30, -11, -11, -14, -6, -22, -26, -25,
-	-25, -29, -32, -19, -20, -29, -26, -49,
-	-23, -28, -36, -19, -15, -20, -33, -42,
+	-16, 6, -6, -7, -4, -22, -30, -17,
+	-32, -26, -19, -16, -25, -27, -27, -39,
+	-20, -18, -26, -31, -29, -24, -17, -25,
+	-11, -9, -17, -12, -21, -17, -19, -7,
+	-18, -17, -15, -17, -23, -22, -24, -34,
+	-32, -11, -12, -15, -9, -22, -26, -27,
+	-27, -30, -32, -21, -22, -30, -27, -56,
+	-33, -33, -36, -22, -17, -21, -38, -53,
 }
 
 var LateRookPst = [64]int16{
-	9, 13, 14, 14, 5, 22, 5, 8,
-	13, 29, 28, 20, 18, 10, 14, -4,
-	14, 12, 18, 8, -4, -2, -12, -12,
-	18, 16, 15, 7, 3, 0, 5, 3,
-	16, 9, 12, 13, 10, 16, -9, -4,
-	15, 5, 13, 10, 6, -1, -18, -11,
-	11, 9, 13, 11, 7, -4, -9, 2,
-	12, 3, 7, -5, -5, -1, -4, 4,
+	13, 17, 19, 20, 13, 22, 7, 9,
+	17, 31, 31, 24, 25, 12, 12, -5,
+	18, 14, 21, 11, -4, 0, -11, -12,
+	16, 18, 15, 9, 6, 2, 3, 4,
+	17, 10, 13, 12, 11, 16, -8, -4,
+	13, 4, 12, 9, 6, -1, -21, -18,
+	6, 7, 10, 10, 7, -3, -9, -3,
+	12, 2, 7, -4, -5, -1, -10, 4,
 }
 
 var LateQueenPst = [64]int16{
-	50, 56, 58, 49, 51, 50, 47, 43,
-	20, 68, 87, 80, 119, 77, 87, 56,
-	22, 35, 56, 76, 89, 87, 89, 48,
-	57, 58, 64, 92, 92, 74, 104, 71,
-	25, 71, 48, 73, 65, 65, 68, 58,
-	40, 9, 49, 35, 41, 55, 44, 35,
-	18, 9, 5, 19, 18, 9, -2, -18,
-	2, 9, 16, -2, 15, 12, 15, 17,
+	53, 63, 65, 54, 63, 55, 52, 49,
+	29, 72, 97, 88, 125, 99, 105, 62,
+	26, 40, 72, 77, 99, 100, 100, 45,
+	58, 59, 72, 88, 99, 82, 107, 68,
+	32, 69, 55, 73, 65, 69, 72, 59,
+	44, 17, 53, 40, 44, 56, 41, 29,
+	24, 13, 11, 24, 23, 13, 1, -23,
+	7, 13, 21, 5, 15, 16, 18, 12,
 }
 
 var LateKingPst = [64]int16{
-	-141, -79, -41, -15, 31, 12, -29, -74,
-	-17, 20, 38, 25, 41, 47, 46, 14,
-	-4, 24, 31, 38, 33, 32, 33, 7,
-	-6, 17, 27, 38, 36, 32, 22, 7,
-	-6, 1, 18, 30, 26, 14, 9, 2,
-	-23, -11, 4, 15, 14, 2, -11, -8,
-	-26, -13, -2, -2, -1, -5, -20, -25,
-	-38, -49, -31, -6, -28, -7, -38, -56,
+	-147, -79, -43, -12, 27, 15, -27, -87,
+	-12, 22, 39, 29, 41, 45, 46, 12,
+	3, 27, 34, 43, 35, 32, 33, 10,
+	-2, 17, 27, 38, 34, 32, 26, 9,
+	-2, 7, 16, 27, 23, 13, 10, 6,
+	-23, -12, 2, 14, 13, 0, -11, -8,
+	-27, -12, -2, -2, -1, -6, -21, -26,
+	-43, -51, -31, -6, -27, -8, -39, -57,
+}
+
+var MiddlegamePassedPawnBonus = [6]int16{
+	3, 0, 0, 23, 34, 19,
+}
+
+var EndgamePassedPawnBonus = [6]int16{
+	0, 2, 27, 49, 87, 34,
 }
 
 var MiddlegameBackwardPawnPenalty int16 = 12
-var EndgameBackwardPawnPenalty int16 = 7
-var MiddlegameIsolatedPawnPenalty int16 = 14
-var EndgameIsolatedPawnPenalty int16 = 6
-var MiddlegameDoublePawnPenalty int16 = 7
+var EndgameBackwardPawnPenalty int16 = 6
+var MiddlegameIsolatedPawnPenalty int16 = 16
+var EndgameIsolatedPawnPenalty int16 = 4
+var MiddlegameDoublePawnPenalty int16 = 5
 var EndgameDoublePawnPenalty int16 = 23
-var MiddlegamePassedPawnAward int16 = 0
-var EndgamePassedPawnAward int16 = 13
-var MiddlegameAdvancedPassedPawnAward int16 = 17
-var EndgameAdvancedPassedPawnAward int16 = 62
-var MiddlegameCandidatePassedPawnAward int16 = 53
-var EndgameCandidatePassedPawnAward int16 = 52
+var MiddlegameCandidatePassedPawnAward int16 = 55
+var EndgameCandidatePassedPawnAward int16 = 45
 var MiddlegameRookOpenFileAward int16 = 37
 var EndgameRookOpenFileAward int16 = 2
 var MiddlegameRookSemiOpenFileAward int16 = 15
-var EndgameRookSemiOpenFileAward int16 = 10
+var EndgameRookSemiOpenFileAward int16 = 7
 var MiddlegameVeritcalDoubleRookAward int16 = 0
-var EndgameVeritcalDoubleRookAward int16 = 19
-var MiddlegameHorizontalDoubleRookAward int16 = 22
-var EndgameHorizontalDoubleRookAward int16 = 7
+var EndgameVeritcalDoubleRookAward int16 = 17
+var MiddlegameHorizontalDoubleRookAward int16 = 20
+var EndgameHorizontalDoubleRookAward int16 = 9
 var MiddlegamePawnFactorCoeff int16 = 1
 var EndgamePawnFactorCoeff int16 = 1
-var MiddlegamePawnSquareControlCoeff int16 = 1
-var EndgamePawnSquareControlCoeff int16 = 7
+var MiddlegamePawnSquareControlCoeff int16 = 0
+var EndgamePawnSquareControlCoeff int16 = 10
 var MiddlegameMinorMobilityFactorCoeff int16 = 3
 var EndgameMinorMobilityFactorCoeff int16 = 3
 var MiddlegameMinorAggressivityFactorCoeff int16 = 5
-var EndgameMinorAggressivityFactorCoeff int16 = 7
+var EndgameMinorAggressivityFactorCoeff int16 = 6
 var MiddlegameMajorMobilityFactorCoeff int16 = 3
 var EndgameMajorMobilityFactorCoeff int16 = 4
 var MiddlegameMajorAggressivityFactorCoeff int16 = 0
-var EndgameMajorAggressivityFactorCoeff int16 = 6
-var MiddlegameInnerPawnToKingAttackCoeff int16 = 6
+var EndgameMajorAggressivityFactorCoeff int16 = 5
+var MiddlegameInnerPawnToKingAttackCoeff int16 = 9
 var EndgameInnerPawnToKingAttackCoeff int16 = 0
 var MiddlegameOuterPawnToKingAttackCoeff int16 = 1
-var EndgameOuterPawnToKingAttackCoeff int16 = 7
-var MiddlegameInnerMinorToKingAttackCoeff int16 = 20
+var EndgameOuterPawnToKingAttackCoeff int16 = 9
+var MiddlegameInnerMinorToKingAttackCoeff int16 = 19
 var EndgameInnerMinorToKingAttackCoeff int16 = 0
 var MiddlegameOuterMinorToKingAttackCoeff int16 = 11
 var EndgameOuterMinorToKingAttackCoeff int16 = 3
-var MiddlegameInnerMajorToKingAttackCoeff int16 = 19
+var MiddlegameInnerMajorToKingAttackCoeff int16 = 18
 var EndgameInnerMajorToKingAttackCoeff int16 = 0
-var MiddlegameOuterMajorToKingAttackCoeff int16 = 6
-var EndgameOuterMajorToKingAttackCoeff int16 = 4
-var MiddlegamePawnShieldPenalty int16 = 16
-var EndgamePawnShieldPenalty int16 = 10
-var MiddlegameNotCastlingPenalty int16 = 55
+var MiddlegameOuterMajorToKingAttackCoeff int16 = 5
+var EndgameOuterMajorToKingAttackCoeff int16 = 3
+var MiddlegamePawnShieldPenalty int16 = 17
+var EndgamePawnShieldPenalty int16 = 8
+var MiddlegameNotCastlingPenalty int16 = 62
 var EndgameNotCastlingPenalty int16 = 0
-var MiddlegameKingZoneOpenFilePenalty int16 = 60
+var MiddlegameKingZoneOpenFilePenalty int16 = 59
 var EndgameKingZoneOpenFilePenalty int16 = 0
-var MiddlegameKingZoneMissingPawnPenalty int16 = 27
+var MiddlegameKingZoneMissingPawnPenalty int16 = 28
 var EndgameKingZoneMissingPawnPenalty int16 = 0
-var MiddlegameKnightOutpostAward int16 = 16
-var EndgameKnightOutpostAward int16 = 30
-var MiddlegameBishopPairAward int16 = 23
-var EndgameBishopPairAward int16 = 50
+var MiddlegameKnightOutpostAward int16 = 15
+var EndgameKnightOutpostAward int16 = 32
+var MiddlegameBishopPairAward int16 = 20
+var EndgameBishopPairAward int16 = 53
 
 var Flip = [64]int16{
 	56, 57, 58, 59, 60, 61, 62, 63,

--- a/engine/eval_utils.go
+++ b/engine/eval_utils.go
@@ -233,19 +233,16 @@ func (p *Position) CountIsolatedPawns(color Color) int16 {
 	return 0
 }
 
-const lowHalf uint64 = 0x00000000FFFFFFFF
-const hiHalf uint64 = 0xFFFFFFFF00000000
-
-func (p *Position) CountPassedPawns(color Color) (int16, int16) {
+func (p *Position) PassedPawns(color Color) uint64 {
 	switch color {
 	case White:
 		passers := wPassedPawns(p.Board.whitePawn, p.Board.blackPawn)
-		return int16(bits.OnesCount64(passers & lowHalf)), int16(bits.OnesCount64(passers & hiHalf))
+		return passers
 	case Black:
 		passers := bPassedPawns(p.Board.blackPawn, p.Board.whitePawn)
-		return int16(bits.OnesCount64(passers & hiHalf)), int16(bits.OnesCount64(passers & lowHalf))
+		return passers
 	}
-	return 0, 0
+	return 0
 }
 
 // We actually cheat here. We treat the knight like a pawn, and find out if

--- a/engine/eval_utils_test.go
+++ b/engine/eval_utils_test.go
@@ -157,15 +157,15 @@ func TestPassedPawns(t *testing.T) {
 	fen := "7k/8/1Pp1P3/3p1p1p/P4p2/1p4P1/7P/K7 w - - 0 1"
 	game := FromFen(fen)
 
-	expectedF, expectedS := int16(1), int16(2)
-	actualF, actualS := game.Position().CountPassedPawns(White)
-	if actualF != expectedF || actualS != expectedS {
-		t.Error(fmt.Sprintf("Expected: (%d, %d)\n, Got: (%d, %d)\n", expectedF, expectedS, actualF, actualS))
+	expected := uint64(1<<E6 | 1<<B6 | 1<<A4)
+	actual := game.Position().PassedPawns(White)
+	if actual != expected {
+		t.Error(fmt.Sprintf("Expected: %d\n, Got: %d\n", expected, actual))
 	}
-	expectedF, expectedS = int16(2), int16(1)
-	actualF, actualS = game.Position().CountPassedPawns(Black)
-	if actualF != expectedF || actualS != expectedS {
-		t.Error(fmt.Sprintf("Expected: (%d, %d)\n, Got: (%d, %d)\n", expectedF, expectedS, actualF, actualS))
+	expected = uint64(1<<B3 | 1<<C6 | 1<<D5)
+	actual = game.Position().PassedPawns(Black)
+	if actual != expected {
+		t.Error(fmt.Sprintf("Expected: %d\n, Got: %d\n", expected, actual))
 	}
 }
 

--- a/evaluation/evaluation.go
+++ b/evaluation/evaluation.go
@@ -43,7 +43,13 @@ const WhiteGShield = uint64(1<<G2 | 1<<G3)
 const WhiteHShield = uint64(1<<H2 | 1<<H3)
 
 const Rank2Fill = uint64(1<<A2 | 1<<B2 | 1<<C2 | 1<<D2 | 1<<E2 | 1<<F2 | 1<<G2 | 1<<H2)
+const Rank3Fill = uint64(1<<A3 | 1<<B3 | 1<<C3 | 1<<D3 | 1<<E3 | 1<<F3 | 1<<G3 | 1<<H3)
+const Rank4Fill = uint64(1<<A4 | 1<<B4 | 1<<C4 | 1<<D4 | 1<<E4 | 1<<F4 | 1<<G4 | 1<<H4)
+const Rank5Fill = uint64(1<<A5 | 1<<B5 | 1<<C5 | 1<<D5 | 1<<E5 | 1<<F5 | 1<<G5 | 1<<H5)
+const Rank6Fill = uint64(1<<A6 | 1<<B6 | 1<<C6 | 1<<D6 | 1<<E6 | 1<<F6 | 1<<G6 | 1<<H6)
 const Rank7Fill = uint64(1<<A7 | 1<<B7 | 1<<C7 | 1<<D7 | 1<<E7 | 1<<F7 | 1<<G7 | 1<<H7)
+
+var RankFills = []uint64{Rank2Fill, Rank3Fill, Rank4Fill, Rank5Fill, Rank6Fill, Rank7Fill}
 
 func PSQT(piece Piece, sq Square, isEndgame bool) int16 {
 	if isEndgame {
@@ -437,19 +443,18 @@ func PawnStructureEval(p *Position) Eval {
 	var blackMG, whiteMG, blackEG, whiteEG int16
 
 	// passed pawns
-	countP, countS := p.CountPassedPawns(Black)
-	blackMG += MiddlegamePassedPawnAward * countP
-	blackEG += EndgamePassedPawnAward * countP
+	bPassers := p.PassedPawns(Black)
+	wPassers := p.PassedPawns(White)
 
-	blackMG += MiddlegameAdvancedPassedPawnAward * countS
-	blackEG += EndgameAdvancedPassedPawnAward * countS
+	for i := 0; i < 6; i++ {
+		wp := int16(bits.OnesCount64(wPassers & RankFills[i]))
+		bp := int16(bits.OnesCount64(bPassers & RankFills[5-i]))
 
-	countP, countS = p.CountPassedPawns(White)
-	whiteMG += MiddlegamePassedPawnAward * countP
-	whiteEG += EndgamePassedPawnAward * countP
-
-	whiteMG += MiddlegameAdvancedPassedPawnAward * countS
-	whiteEG += EndgameAdvancedPassedPawnAward * countS
+		whiteMG += wp * MiddlegamePassedPawnBonus[i]
+		whiteEG += wp * EndgamePassedPawnBonus[i]
+		blackMG += bp * MiddlegamePassedPawnBonus[i]
+		blackEG += bp * EndgamePassedPawnBonus[i]
+	}
 
 	// candidate passed pawns
 	count := p.CountCandidatePawns(Black)

--- a/evaluation/evaluation_test.go
+++ b/evaluation/evaluation_test.go
@@ -75,7 +75,7 @@ func TestPawnStructureEval(t *testing.T) {
 	game := FromFen(fen)
 
 	actual := Evaluate(game.Position(), NewPawnCache(DEFAULT_PAWNHASH_SIZE))
-	expected := int16(-9)
+	expected := int16(-10)
 
 	if actual != expected {
 		err := fmt.Sprintf("Backward Pawn - White:\nExpected: %d\nGot: %d\n", expected, actual)
@@ -86,7 +86,7 @@ func TestPawnStructureEval(t *testing.T) {
 	game = FromFen(fen)
 
 	actual = Evaluate(game.Position(), NewPawnCache(DEFAULT_PAWNHASH_SIZE))
-	expected = int16(-9)
+	expected = int16(-10)
 
 	if actual != expected {
 		err := fmt.Sprintf("Backward Pawn - Black:\nExpected: %d\nGot: %d\n", expected, actual)
@@ -99,7 +99,7 @@ func TestRookStructureEval(t *testing.T) {
 	game := FromFen(fen)
 
 	actual := Evaluate(game.Position(), NewPawnCache(DEFAULT_PAWNHASH_SIZE))
-	expected := int16(50)
+	expected := int16(42)
 
 	if actual != expected {
 		err := fmt.Sprintf("Semi-open file - White:\nExpected: %d\nGot: %d\n", expected, actual)
@@ -110,7 +110,7 @@ func TestRookStructureEval(t *testing.T) {
 	game = FromFen(fen)
 
 	actual = Evaluate(game.Position(), NewPawnCache(DEFAULT_PAWNHASH_SIZE))
-	expected = int16(50)
+	expected = int16(42)
 
 	if actual != expected {
 		err := fmt.Sprintf("Semi-open file - Black:\nExpected: %d\nGot: %d\n", expected, actual)

--- a/evaluation/pawnhash.go
+++ b/evaluation/pawnhash.go
@@ -56,3 +56,7 @@ func NewPawnCache(megabytes int) *PawnCache {
 	size := int(megabytes * 1024 * 1024 / PAWN_ENTRY_SIZE)
 	return &PawnCache{make([]PawnEval, RoundPowerOfTwo(size)), 1, 0, 0}
 }
+
+func NewDummyPawnCache() *PawnCache {
+	return &PawnCache{make([]PawnEval, 1), 1, 0, 0}
+}

--- a/search/quiescence.go
+++ b/search/quiescence.go
@@ -101,7 +101,6 @@ func (e *Engine) quiescence(alpha int16, beta int16, searchHeight int8) int16 {
 			continue
 		}
 
-		// promoType := move.PromoType()
 		if !IsPromoting(move) {
 			margin := p + move.CapturedPiece().Weight()
 			if standPat+margin <= alpha {

--- a/search/search.go
+++ b/search/search.go
@@ -570,7 +570,6 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 			if isCaptureMove && seeScores[noisyMoves] < 0 &&
 				depthLeft <= 2 && eval <= alpha && abs16(alpha) < WIN_IN_MAX {
 				e.info.seeCounter += 1
-				// position.UnMakeMove(move, oldTag, oldEnPassant, hc)
 				continue
 			}
 
@@ -600,7 +599,11 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 				e.info.lmrCounter += 1
 				LMR = int8(lmrReductions[min8(31, depthLeft)][min(31, legalMoves)])
 
-				// if killerScore > 0 {
+				// if !isInCheck {
+				// 	LMR += 1
+				// }
+				//
+				// if isKiller {
 				// 	LMR -= 1
 				// }
 

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -164,7 +164,7 @@ func TestReubenFineBasicChessEndingsPosition70(t *testing.T) {
 	r.AddTimeManager(NewTimeManager(time.Now(), 400_000, true, 0, 0, false))
 	e := r.Engines[0]
 	e.Position = game.Position()
-	e.Search(30)
+	e.Search(25)
 	expected := NewMove(A1, B1, WhiteKing, NoPiece, NoType, 0)
 	mv := r.Move()
 	mvStr := mv.ToString()

--- a/tuning/texel_tuning.go
+++ b/tuning/texel_tuning.go
@@ -29,7 +29,7 @@ var initialK = 1.0
 var skipParams map[int]bool
 var answers = make(chan float64)
 var ml = NewMoveList(500)
-var pawnhash = NewPawnCache(2)
+var pawnhash = NewDummyPawnCache()
 
 func initEngines() []*Engine {
 	res := make([]*Engine, NUM_PROCESSORS)
@@ -72,62 +72,60 @@ func computeInitialGuesses() []int16 {
 	guesses = append(guesses, LateQueenPst[:]...)                     // 576-639
 	guesses = append(guesses, EarlyKingPst[:]...)                     // 640-703
 	guesses = append(guesses, LateKingPst[:]...)                      // 704-767
-	guesses = append(guesses, MiddlegameBackwardPawnPenalty)          // 768
-	guesses = append(guesses, EndgameBackwardPawnPenalty)             // 769
-	guesses = append(guesses, MiddlegameIsolatedPawnPenalty)          // 770
-	guesses = append(guesses, EndgameIsolatedPawnPenalty)             // 771
-	guesses = append(guesses, MiddlegameDoublePawnPenalty)            // 772
-	guesses = append(guesses, EndgameDoublePawnPenalty)               // 773
-	guesses = append(guesses, MiddlegamePassedPawnAward)              // 774
-	guesses = append(guesses, EndgamePassedPawnAward)                 // 775
-	guesses = append(guesses, MiddlegameAdvancedPassedPawnAward)      // 776
-	guesses = append(guesses, EndgameAdvancedPassedPawnAward)         // 777
-	guesses = append(guesses, MiddlegameCandidatePassedPawnAward)     // 778
-	guesses = append(guesses, EndgameCandidatePassedPawnAward)        // 779
-	guesses = append(guesses, MiddlegameRookOpenFileAward)            // 780
-	guesses = append(guesses, EndgameRookOpenFileAward)               // 781
-	guesses = append(guesses, MiddlegameRookSemiOpenFileAward)        // 782
-	guesses = append(guesses, EndgameRookSemiOpenFileAward)           // 783
-	guesses = append(guesses, MiddlegameVeritcalDoubleRookAward)      // 784
-	guesses = append(guesses, EndgameVeritcalDoubleRookAward)         // 785
-	guesses = append(guesses, MiddlegameHorizontalDoubleRookAward)    // 786
-	guesses = append(guesses, EndgameHorizontalDoubleRookAward)       // 787
-	guesses = append(guesses, MiddlegamePawnFactorCoeff)              // 788
-	guesses = append(guesses, EndgamePawnFactorCoeff)                 // 789
-	guesses = append(guesses, MiddlegamePawnSquareControlCoeff)       // 790
-	guesses = append(guesses, EndgamePawnSquareControlCoeff)          // 791
-	guesses = append(guesses, MiddlegameMinorMobilityFactorCoeff)     // 792
-	guesses = append(guesses, EndgameMinorMobilityFactorCoeff)        // 793
-	guesses = append(guesses, MiddlegameMinorAggressivityFactorCoeff) // 794
-	guesses = append(guesses, EndgameMinorAggressivityFactorCoeff)    // 795
-	guesses = append(guesses, MiddlegameMajorMobilityFactorCoeff)     // 796
-	guesses = append(guesses, EndgameMajorMobilityFactorCoeff)        // 797
-	guesses = append(guesses, MiddlegameMajorAggressivityFactorCoeff) // 798
-	guesses = append(guesses, EndgameMajorAggressivityFactorCoeff)    // 799
-	guesses = append(guesses, MiddlegameInnerPawnToKingAttackCoeff)   // 800
-	guesses = append(guesses, EndgameInnerPawnToKingAttackCoeff)      // 801
-	guesses = append(guesses, MiddlegameOuterPawnToKingAttackCoeff)   // 802
-	guesses = append(guesses, EndgameOuterPawnToKingAttackCoeff)      // 803
-	guesses = append(guesses, MiddlegameInnerMinorToKingAttackCoeff)  // 804
-	guesses = append(guesses, EndgameInnerMinorToKingAttackCoeff)     // 805
-	guesses = append(guesses, MiddlegameOuterMinorToKingAttackCoeff)  // 806
-	guesses = append(guesses, EndgameOuterMinorToKingAttackCoeff)     // 807
-	guesses = append(guesses, MiddlegameInnerMajorToKingAttackCoeff)  // 808
-	guesses = append(guesses, EndgameInnerMajorToKingAttackCoeff)     // 809
-	guesses = append(guesses, MiddlegameOuterMajorToKingAttackCoeff)  // 810
-	guesses = append(guesses, EndgameOuterMajorToKingAttackCoeff)     // 811
-	guesses = append(guesses, MiddlegamePawnShieldPenalty)            // 812
-	guesses = append(guesses, EndgamePawnShieldPenalty)               // 813
-	guesses = append(guesses, MiddlegameNotCastlingPenalty)           // 814
-	guesses = append(guesses, EndgameNotCastlingPenalty)              // 815
-	guesses = append(guesses, MiddlegameKingZoneOpenFilePenalty)      // 816
-	guesses = append(guesses, EndgameKingZoneOpenFilePenalty)         // 817
-	guesses = append(guesses, MiddlegameKingZoneMissingPawnPenalty)   // 818
-	guesses = append(guesses, EndgameKingZoneMissingPawnPenalty)      // 819
-	guesses = append(guesses, MiddlegameKnightOutpostAward)           // 820
-	guesses = append(guesses, EndgameKnightOutpostAward)              // 821
-	guesses = append(guesses, MiddlegameBishopPairAward)              // 822
-	guesses = append(guesses, EndgameBishopPairAward)                 // 823
+	guesses = append(guesses, MiddlegamePassedPawnBonus[:]...)        // 768-773
+	guesses = append(guesses, EndgamePassedPawnBonus[:]...)           // 774-779
+	guesses = append(guesses, MiddlegameBackwardPawnPenalty)          // 780
+	guesses = append(guesses, EndgameBackwardPawnPenalty)             // 781
+	guesses = append(guesses, MiddlegameIsolatedPawnPenalty)          // 782
+	guesses = append(guesses, EndgameIsolatedPawnPenalty)             // 783
+	guesses = append(guesses, MiddlegameDoublePawnPenalty)            // 784
+	guesses = append(guesses, EndgameDoublePawnPenalty)               // 785
+	guesses = append(guesses, MiddlegameCandidatePassedPawnAward)     // 786
+	guesses = append(guesses, EndgameCandidatePassedPawnAward)        // 787
+	guesses = append(guesses, MiddlegameRookOpenFileAward)            // 788
+	guesses = append(guesses, EndgameRookOpenFileAward)               // 789
+	guesses = append(guesses, MiddlegameRookSemiOpenFileAward)        // 790
+	guesses = append(guesses, EndgameRookSemiOpenFileAward)           // 791
+	guesses = append(guesses, MiddlegameVeritcalDoubleRookAward)      // 792
+	guesses = append(guesses, EndgameVeritcalDoubleRookAward)         // 793
+	guesses = append(guesses, MiddlegameHorizontalDoubleRookAward)    // 794
+	guesses = append(guesses, EndgameHorizontalDoubleRookAward)       // 795
+	guesses = append(guesses, MiddlegamePawnFactorCoeff)              // 796
+	guesses = append(guesses, EndgamePawnFactorCoeff)                 // 797
+	guesses = append(guesses, MiddlegamePawnSquareControlCoeff)       // 798
+	guesses = append(guesses, EndgamePawnSquareControlCoeff)          // 799
+	guesses = append(guesses, MiddlegameMinorMobilityFactorCoeff)     // 800
+	guesses = append(guesses, EndgameMinorMobilityFactorCoeff)        // 801
+	guesses = append(guesses, MiddlegameMinorAggressivityFactorCoeff) // 802
+	guesses = append(guesses, EndgameMinorAggressivityFactorCoeff)    // 803
+	guesses = append(guesses, MiddlegameMajorMobilityFactorCoeff)     // 804
+	guesses = append(guesses, EndgameMajorMobilityFactorCoeff)        // 805
+	guesses = append(guesses, MiddlegameMajorAggressivityFactorCoeff) // 806
+	guesses = append(guesses, EndgameMajorAggressivityFactorCoeff)    // 807
+	guesses = append(guesses, MiddlegameInnerPawnToKingAttackCoeff)   // 808
+	guesses = append(guesses, EndgameInnerPawnToKingAttackCoeff)      // 809
+	guesses = append(guesses, MiddlegameOuterPawnToKingAttackCoeff)   // 810
+	guesses = append(guesses, EndgameOuterPawnToKingAttackCoeff)      // 811
+	guesses = append(guesses, MiddlegameInnerMinorToKingAttackCoeff)  // 812
+	guesses = append(guesses, EndgameInnerMinorToKingAttackCoeff)     // 813
+	guesses = append(guesses, MiddlegameOuterMinorToKingAttackCoeff)  // 814
+	guesses = append(guesses, EndgameOuterMinorToKingAttackCoeff)     // 815
+	guesses = append(guesses, MiddlegameInnerMajorToKingAttackCoeff)  // 816
+	guesses = append(guesses, EndgameInnerMajorToKingAttackCoeff)     // 817
+	guesses = append(guesses, MiddlegameOuterMajorToKingAttackCoeff)  // 818
+	guesses = append(guesses, EndgameOuterMajorToKingAttackCoeff)     // 819
+	guesses = append(guesses, MiddlegamePawnShieldPenalty)            // 820
+	guesses = append(guesses, EndgamePawnShieldPenalty)               // 821
+	guesses = append(guesses, MiddlegameNotCastlingPenalty)           // 822
+	guesses = append(guesses, EndgameNotCastlingPenalty)              // 823
+	guesses = append(guesses, MiddlegameKingZoneOpenFilePenalty)      // 824
+	guesses = append(guesses, EndgameKingZoneOpenFilePenalty)         // 825
+	guesses = append(guesses, MiddlegameKingZoneMissingPawnPenalty)   // 826
+	guesses = append(guesses, EndgameKingZoneMissingPawnPenalty)      // 827
+	guesses = append(guesses, MiddlegameKnightOutpostAward)           // 828
+	guesses = append(guesses, EndgameKnightOutpostAward)              // 829
+	guesses = append(guesses, MiddlegameBishopPairAward)              // 830
+	guesses = append(guesses, EndgameBishopPairAward)                 // 831
 
 	return guesses
 }
@@ -147,64 +145,66 @@ func updateEvalParams(guesses []int16) {
 		EarlyKingPst[i] = guesses[i+10*64]
 		LateKingPst[i] = guesses[i+11*64]
 	}
-	MiddlegameBackwardPawnPenalty = guesses[768]
-	EndgameBackwardPawnPenalty = guesses[769]
-	MiddlegameIsolatedPawnPenalty = guesses[770]
-	EndgameIsolatedPawnPenalty = guesses[771]
-	MiddlegameDoublePawnPenalty = guesses[772]
-	EndgameDoublePawnPenalty = guesses[773]
-	MiddlegamePassedPawnAward = guesses[774]
-	EndgamePassedPawnAward = guesses[775]
-	MiddlegameAdvancedPassedPawnAward = guesses[776]
-	EndgameAdvancedPassedPawnAward = guesses[777]
-	MiddlegameCandidatePassedPawnAward = guesses[778]
-	EndgameCandidatePassedPawnAward = guesses[779]
-	MiddlegameRookOpenFileAward = guesses[780]
-	EndgameRookOpenFileAward = guesses[781]
-	MiddlegameRookSemiOpenFileAward = guesses[782]
-	EndgameRookSemiOpenFileAward = guesses[783]
-	MiddlegameVeritcalDoubleRookAward = guesses[784]
-	EndgameVeritcalDoubleRookAward = guesses[785]
-	MiddlegameHorizontalDoubleRookAward = guesses[786]
-	EndgameHorizontalDoubleRookAward = guesses[787]
-	MiddlegamePawnFactorCoeff = guesses[788]
-	EndgamePawnFactorCoeff = guesses[789]
-	MiddlegamePawnSquareControlCoeff = guesses[790]
-	EndgamePawnSquareControlCoeff = guesses[791]
-	MiddlegameMinorMobilityFactorCoeff = guesses[792]
-	EndgameMinorMobilityFactorCoeff = guesses[793]
-	MiddlegameMinorAggressivityFactorCoeff = guesses[794]
-	EndgameMinorAggressivityFactorCoeff = guesses[795]
-	MiddlegameMajorMobilityFactorCoeff = guesses[796]
-	EndgameMajorMobilityFactorCoeff = guesses[797]
-	MiddlegameMajorAggressivityFactorCoeff = guesses[798]
-	EndgameMajorAggressivityFactorCoeff = guesses[799]
-	MiddlegameInnerPawnToKingAttackCoeff = guesses[800]
-	EndgameInnerPawnToKingAttackCoeff = guesses[801]
-	MiddlegameOuterPawnToKingAttackCoeff = guesses[802]
-	EndgameOuterPawnToKingAttackCoeff = guesses[803]
-	MiddlegameInnerMinorToKingAttackCoeff = guesses[804]
-	EndgameInnerMinorToKingAttackCoeff = guesses[805]
-	MiddlegameOuterMinorToKingAttackCoeff = guesses[806]
-	EndgameOuterMinorToKingAttackCoeff = guesses[807]
-	MiddlegameInnerMajorToKingAttackCoeff = guesses[808]
-	EndgameInnerMajorToKingAttackCoeff = guesses[809]
-	MiddlegameOuterMajorToKingAttackCoeff = guesses[810]
-	EndgameOuterMajorToKingAttackCoeff = guesses[811]
-	MiddlegamePawnShieldPenalty = guesses[812]
-	EndgamePawnShieldPenalty = guesses[813]
-	MiddlegameNotCastlingPenalty = guesses[814]
-	EndgameNotCastlingPenalty = guesses[815]
-	MiddlegameKingZoneOpenFilePenalty = guesses[816]
-	EndgameKingZoneOpenFilePenalty = guesses[817]
-	MiddlegameKingZoneMissingPawnPenalty = guesses[818]
-	EndgameKingZoneMissingPawnPenalty = guesses[819]
-	MiddlegameKnightOutpostAward = guesses[820]
-	EndgameKnightOutpostAward = guesses[821]
-	MiddlegameBishopPairAward = guesses[822]
-	EndgameBishopPairAward = guesses[823]
+	for i := 0; i < 6; i++ {
+		MiddlegamePassedPawnBonus[i] = guesses[768+i]
+		EndgamePassedPawnBonus[i] = guesses[768+6+i]
+	}
+
+	MiddlegameBackwardPawnPenalty = guesses[780]
+	EndgameBackwardPawnPenalty = guesses[781]
+	MiddlegameIsolatedPawnPenalty = guesses[782]
+	EndgameIsolatedPawnPenalty = guesses[783]
+	MiddlegameDoublePawnPenalty = guesses[784]
+	EndgameDoublePawnPenalty = guesses[785]
+	MiddlegameCandidatePassedPawnAward = guesses[786]
+	EndgameCandidatePassedPawnAward = guesses[787]
+	MiddlegameRookOpenFileAward = guesses[788]
+	EndgameRookOpenFileAward = guesses[789]
+	MiddlegameRookSemiOpenFileAward = guesses[790]
+	EndgameRookSemiOpenFileAward = guesses[791]
+	MiddlegameVeritcalDoubleRookAward = guesses[792]
+	EndgameVeritcalDoubleRookAward = guesses[793]
+	MiddlegameHorizontalDoubleRookAward = guesses[794]
+	EndgameHorizontalDoubleRookAward = guesses[795]
+	MiddlegamePawnFactorCoeff = guesses[796]
+	EndgamePawnFactorCoeff = guesses[797]
+	MiddlegamePawnSquareControlCoeff = guesses[798]
+	EndgamePawnSquareControlCoeff = guesses[799]
+	MiddlegameMinorMobilityFactorCoeff = guesses[800]
+	EndgameMinorMobilityFactorCoeff = guesses[801]
+	MiddlegameMinorAggressivityFactorCoeff = guesses[802]
+	EndgameMinorAggressivityFactorCoeff = guesses[803]
+	MiddlegameMajorMobilityFactorCoeff = guesses[804]
+	EndgameMajorMobilityFactorCoeff = guesses[805]
+	MiddlegameMajorAggressivityFactorCoeff = guesses[806]
+	EndgameMajorAggressivityFactorCoeff = guesses[807]
+	MiddlegameInnerPawnToKingAttackCoeff = guesses[808]
+	EndgameInnerPawnToKingAttackCoeff = guesses[809]
+	MiddlegameOuterPawnToKingAttackCoeff = guesses[810]
+	EndgameOuterPawnToKingAttackCoeff = guesses[811]
+	MiddlegameInnerMinorToKingAttackCoeff = guesses[812]
+	EndgameInnerMinorToKingAttackCoeff = guesses[813]
+	MiddlegameOuterMinorToKingAttackCoeff = guesses[814]
+	EndgameOuterMinorToKingAttackCoeff = guesses[815]
+	MiddlegameInnerMajorToKingAttackCoeff = guesses[816]
+	EndgameInnerMajorToKingAttackCoeff = guesses[817]
+	MiddlegameOuterMajorToKingAttackCoeff = guesses[818]
+	EndgameOuterMajorToKingAttackCoeff = guesses[819]
+	MiddlegamePawnShieldPenalty = guesses[820]
+	EndgamePawnShieldPenalty = guesses[821]
+	MiddlegameNotCastlingPenalty = guesses[822]
+	EndgameNotCastlingPenalty = guesses[823]
+	MiddlegameKingZoneOpenFilePenalty = guesses[824]
+	EndgameKingZoneOpenFilePenalty = guesses[825]
+	MiddlegameKingZoneMissingPawnPenalty = guesses[826]
+	EndgameKingZoneMissingPawnPenalty = guesses[827]
+	MiddlegameKnightOutpostAward = guesses[828]
+	EndgameKnightOutpostAward = guesses[829]
+	MiddlegameBishopPairAward = guesses[830]
+	EndgameBishopPairAward = guesses[831]
 
 	UpdatePSQTs()
+	pawnhash = NewDummyPawnCache()
 }
 
 func toEvalParams(guesses []float64) []int16 {
@@ -215,91 +215,89 @@ func toEvalParams(guesses []float64) []int16 {
 	return params
 }
 
-func printPst(pst []int16, varname string) {
+func printArray(pst []int16, varname string) {
 	acc := ""
-	for i := 0; i < 64; i++ {
+	for i := 0; i < len(pst); i++ {
 		if i%8 == 0 {
 			acc = fmt.Sprintf("%s\n", acc)
 		}
 		acc = fmt.Sprintf("%s %d,", acc, pst[i])
 	}
-	fmt.Printf("var %s = [64]int16 { %s \n}\n\n", varname, acc)
+	fmt.Printf("var %s = [%d]int16 { %s \n}\n\n", varname, len(pst), acc)
 }
 
 func printOptimalGuesses(guesses []int16) {
 	fmt.Println("// Middle-game")
-	printPst(guesses[0:64], "EarlyPawnPst")
-	printPst(guesses[128:192], "EarlyKnightPst")
-	printPst(guesses[256:320], "EarlyBishopPst")
-	printPst(guesses[384:448], "EarlyRookPst")
-	printPst(guesses[512:576], "EarlyQueenPst")
-	printPst(guesses[640:704], "EarlyKingPst")
+	printArray(guesses[0:64], "EarlyPawnPst")
+	printArray(guesses[128:192], "EarlyKnightPst")
+	printArray(guesses[256:320], "EarlyBishopPst")
+	printArray(guesses[384:448], "EarlyRookPst")
+	printArray(guesses[512:576], "EarlyQueenPst")
+	printArray(guesses[640:704], "EarlyKingPst")
 	fmt.Println("// Endgame")
-	printPst(guesses[64:128], "LatePawnPst")
-	printPst(guesses[192:256], "LateKnightPst")
-	printPst(guesses[320:384], "LateBishopPst")
-	printPst(guesses[448:512], "LateRookPst")
-	printPst(guesses[576:640], "LateQueenPst")
-	printPst(guesses[704:768], "LateKingPst")
+	printArray(guesses[64:128], "LatePawnPst")
+	printArray(guesses[192:256], "LateKnightPst")
+	printArray(guesses[320:384], "LateBishopPst")
+	printArray(guesses[448:512], "LateRookPst")
+	printArray(guesses[576:640], "LateQueenPst")
+	printArray(guesses[704:768], "LateKingPst")
 
-	fmt.Printf("var MiddlegameBackwardPawnPenalty int16 = %d\n", guesses[768])
-	fmt.Printf("var EndgameBackwardPawnPenalty int16 = %d\n", guesses[769])
-	fmt.Printf("var MiddlegameIsolatedPawnPenalty int16 = %d\n", guesses[770])
-	fmt.Printf("var EndgameIsolatedPawnPenalty int16 = %d\n", guesses[771])
-	fmt.Printf("var MiddlegameDoublePawnPenalty int16 = %d\n", guesses[772])
-	fmt.Printf("var EndgameDoublePawnPenalty int16 = %d\n", guesses[773])
-	fmt.Printf("var MiddlegamePassedPawnAward int16 = %d\n", guesses[774])
-	fmt.Printf("var EndgamePassedPawnAward int16 = %d\n", guesses[775])
-	fmt.Printf("var MiddlegameAdvancedPassedPawnAward int16 = %d\n", guesses[776])
-	fmt.Printf("var EndgameAdvancedPassedPawnAward int16 = %d\n", guesses[777])
-	fmt.Printf("var MiddlegameCandidatePassedPawnAward int16 = %d\n", guesses[778])
-	fmt.Printf("var EndgameCandidatePassedPawnAward int16 = %d\n", guesses[779])
-	fmt.Printf("var MiddlegameRookOpenFileAward int16 = %d\n", guesses[780])
-	fmt.Printf("var EndgameRookOpenFileAward int16 = %d\n", guesses[781])
-	fmt.Printf("var MiddlegameRookSemiOpenFileAward int16 = %d\n", guesses[782])
-	fmt.Printf("var EndgameRookSemiOpenFileAward int16 = %d\n", guesses[783])
-	fmt.Printf("var MiddlegameVeritcalDoubleRookAward int16 = %d\n", guesses[784])
-	fmt.Printf("var EndgameVeritcalDoubleRookAward int16 = %d\n", guesses[785])
-	fmt.Printf("var MiddlegameHorizontalDoubleRookAward int16 = %d\n", guesses[786])
-	fmt.Printf("var EndgameHorizontalDoubleRookAward int16 = %d\n", guesses[787])
-	fmt.Printf("var MiddlegamePawnFactorCoeff int16 = %d\n", guesses[788])
-	fmt.Printf("var EndgamePawnFactorCoeff int16 = %d\n", guesses[789])
-	fmt.Printf("var MiddlegamePawnSquareControlCoeff int16 = %d\n", guesses[790])
-	fmt.Printf("var EndgamePawnSquareControlCoeff int16 = %d\n", guesses[791])
-	fmt.Printf("var MiddlegameMinorMobilityFactorCoeff int16 = %d\n", guesses[792])
-	fmt.Printf("var EndgameMinorMobilityFactorCoeff int16 = %d\n", guesses[793])
-	fmt.Printf("var MiddlegameMinorAggressivityFactorCoeff int16 = %d\n", guesses[794])
-	fmt.Printf("var EndgameMinorAggressivityFactorCoeff int16 = %d\n", guesses[795])
-	fmt.Printf("var MiddlegameMajorMobilityFactorCoeff int16 = %d\n", guesses[796])
-	fmt.Printf("var EndgameMajorMobilityFactorCoeff int16 = %d\n", guesses[797])
-	fmt.Printf("var MiddlegameMajorAggressivityFactorCoeff int16 = %d\n", guesses[798])
-	fmt.Printf("var EndgameMajorAggressivityFactorCoeff int16 = %d\n", guesses[799])
-	fmt.Printf("var MiddlegameInnerPawnToKingAttackCoeff int16 = %d\n", guesses[800])
-	fmt.Printf("var EndgameInnerPawnToKingAttackCoeff int16 = %d\n", guesses[801])
-	fmt.Printf("var MiddlegameOuterPawnToKingAttackCoeff int16 = %d\n", guesses[802])
-	fmt.Printf("var EndgameOuterPawnToKingAttackCoeff int16 = %d\n", guesses[803])
-	fmt.Printf("var MiddlegameInnerMinorToKingAttackCoeff int16 = %d\n", guesses[804])
-	fmt.Printf("var EndgameInnerMinorToKingAttackCoeff int16 = %d\n", guesses[805])
-	fmt.Printf("var MiddlegameOuterMinorToKingAttackCoeff int16 = %d\n", guesses[806])
-	fmt.Printf("var EndgameOuterMinorToKingAttackCoeff int16 = %d\n", guesses[807])
-	fmt.Printf("var MiddlegameInnerMajorToKingAttackCoeff int16 = %d\n", guesses[808])
-	fmt.Printf("var EndgameInnerMajorToKingAttackCoeff int16 = %d\n", guesses[809])
-	fmt.Printf("var MiddlegameOuterMajorToKingAttackCoeff int16 = %d\n", guesses[810])
-	fmt.Printf("var EndgameOuterMajorToKingAttackCoeff int16 = %d\n", guesses[811])
-	fmt.Printf("var MiddlegamePawnShieldPenalty int16 = %d\n", guesses[812])
-	fmt.Printf("var EndgamePawnShieldPenalty int16 = %d\n", guesses[813])
-	fmt.Printf("var MiddlegameNotCastlingPenalty int16 = %d\n", guesses[814])
-	fmt.Printf("var EndgameNotCastlingPenalty int16 = %d\n", guesses[815])
-	fmt.Printf("var MiddlegameKingZoneOpenFilePenalty int16 = %d\n", guesses[816])
-	fmt.Printf("var EndgameKingZoneOpenFilePenalty int16 = %d\n", guesses[817])
-	fmt.Printf("var MiddlegameKingZoneMissingPawnPenalty int16 = %d\n", guesses[818])
-	fmt.Printf("var EndgameKingZoneMissingPawnPenalty int16 = %d\n", guesses[819])
-	fmt.Printf("var MiddlegameKnightOutpostAward int16 = %d\n", guesses[820])
-	fmt.Printf("var EndgameKnightOutpostAward int16 = %d\n", guesses[821])
-	fmt.Printf("var MiddlegameBishopPairAward int16 = %d\n", guesses[822])
-	fmt.Printf("var EndgameBishopPairAward int16 = %d\n", guesses[823])
+	printArray(guesses[768:774], "MiddlegamePassedPawnBonus")
+	printArray(guesses[774:780], "EndgamePassedPawnBonus")
 
-	// fmt.Printf("var MiddlegameCastlingAward int16 = %d\n", guesses[792])
+	fmt.Printf("var MiddlegameBackwardPawnPenalty int16 = %d\n", guesses[780])
+	fmt.Printf("var EndgameBackwardPawnPenalty int16 = %d\n", guesses[781])
+	fmt.Printf("var MiddlegameIsolatedPawnPenalty int16 = %d\n", guesses[782])
+	fmt.Printf("var EndgameIsolatedPawnPenalty int16 = %d\n", guesses[783])
+	fmt.Printf("var MiddlegameDoublePawnPenalty int16 = %d\n", guesses[784])
+	fmt.Printf("var EndgameDoublePawnPenalty int16 = %d\n", guesses[785])
+	fmt.Printf("var MiddlegameCandidatePassedPawnAward int16 = %d\n", guesses[786])
+	fmt.Printf("var EndgameCandidatePassedPawnAward int16 = %d\n", guesses[787])
+	fmt.Printf("var MiddlegameRookOpenFileAward int16 = %d\n", guesses[788])
+	fmt.Printf("var EndgameRookOpenFileAward int16 = %d\n", guesses[789])
+	fmt.Printf("var MiddlegameRookSemiOpenFileAward int16 = %d\n", guesses[790])
+	fmt.Printf("var EndgameRookSemiOpenFileAward int16 = %d\n", guesses[791])
+	fmt.Printf("var MiddlegameVeritcalDoubleRookAward int16 = %d\n", guesses[792])
+	fmt.Printf("var EndgameVeritcalDoubleRookAward int16 = %d\n", guesses[793])
+	fmt.Printf("var MiddlegameHorizontalDoubleRookAward int16 = %d\n", guesses[794])
+	fmt.Printf("var EndgameHorizontalDoubleRookAward int16 = %d\n", guesses[795])
+	fmt.Printf("var MiddlegamePawnFactorCoeff int16 = %d\n", guesses[796])
+	fmt.Printf("var EndgamePawnFactorCoeff int16 = %d\n", guesses[797])
+	fmt.Printf("var MiddlegamePawnSquareControlCoeff int16 = %d\n", guesses[798])
+	fmt.Printf("var EndgamePawnSquareControlCoeff int16 = %d\n", guesses[799])
+	fmt.Printf("var MiddlegameMinorMobilityFactorCoeff int16 = %d\n", guesses[800])
+	fmt.Printf("var EndgameMinorMobilityFactorCoeff int16 = %d\n", guesses[801])
+	fmt.Printf("var MiddlegameMinorAggressivityFactorCoeff int16 = %d\n", guesses[802])
+	fmt.Printf("var EndgameMinorAggressivityFactorCoeff int16 = %d\n", guesses[803])
+	fmt.Printf("var MiddlegameMajorMobilityFactorCoeff int16 = %d\n", guesses[804])
+	fmt.Printf("var EndgameMajorMobilityFactorCoeff int16 = %d\n", guesses[805])
+	fmt.Printf("var MiddlegameMajorAggressivityFactorCoeff int16 = %d\n", guesses[806])
+	fmt.Printf("var EndgameMajorAggressivityFactorCoeff int16 = %d\n", guesses[807])
+	fmt.Printf("var MiddlegameInnerPawnToKingAttackCoeff int16 = %d\n", guesses[808])
+	fmt.Printf("var EndgameInnerPawnToKingAttackCoeff int16 = %d\n", guesses[809])
+	fmt.Printf("var MiddlegameOuterPawnToKingAttackCoeff int16 = %d\n", guesses[810])
+	fmt.Printf("var EndgameOuterPawnToKingAttackCoeff int16 = %d\n", guesses[811])
+	fmt.Printf("var MiddlegameInnerMinorToKingAttackCoeff int16 = %d\n", guesses[812])
+	fmt.Printf("var EndgameInnerMinorToKingAttackCoeff int16 = %d\n", guesses[813])
+	fmt.Printf("var MiddlegameOuterMinorToKingAttackCoeff int16 = %d\n", guesses[814])
+	fmt.Printf("var EndgameOuterMinorToKingAttackCoeff int16 = %d\n", guesses[815])
+	fmt.Printf("var MiddlegameInnerMajorToKingAttackCoeff int16 = %d\n", guesses[816])
+	fmt.Printf("var EndgameInnerMajorToKingAttackCoeff int16 = %d\n", guesses[817])
+	fmt.Printf("var MiddlegameOuterMajorToKingAttackCoeff int16 = %d\n", guesses[818])
+	fmt.Printf("var EndgameOuterMajorToKingAttackCoeff int16 = %d\n", guesses[819])
+	fmt.Printf("var MiddlegamePawnShieldPenalty int16 = %d\n", guesses[820])
+	fmt.Printf("var EndgamePawnShieldPenalty int16 = %d\n", guesses[821])
+	fmt.Printf("var MiddlegameNotCastlingPenalty int16 = %d\n", guesses[822])
+	fmt.Printf("var EndgameNotCastlingPenalty int16 = %d\n", guesses[823])
+	fmt.Printf("var MiddlegameKingZoneOpenFilePenalty int16 = %d\n", guesses[824])
+	fmt.Printf("var EndgameKingZoneOpenFilePenalty int16 = %d\n", guesses[825])
+	fmt.Printf("var MiddlegameKingZoneMissingPawnPenalty int16 = %d\n", guesses[826])
+	fmt.Printf("var EndgameKingZoneMissingPawnPenalty int16 = %d\n", guesses[827])
+	fmt.Printf("var MiddlegameKnightOutpostAward int16 = %d\n", guesses[828])
+	fmt.Printf("var EndgameKnightOutpostAward int16 = %d\n", guesses[829])
+	fmt.Printf("var MiddlegameBishopPairAward int16 = %d\n", guesses[830])
+	fmt.Printf("var EndgameBishopPairAward int16 = %d\n", guesses[831])
+
 	fmt.Println("===================================================")
 }
 


### PR DESCRIPTION
```
Score of zahak_next vs zahak_master: 7922 - 7719 - 11481  [0.504] 27122
...      zahak_next playing White: 4490 - 3385 - 5687  [0.541] 13562
...      zahak_next playing Black: 3432 - 4334 - 5794  [0.467] 13560
...      White vs Black: 8824 - 6817 - 11481  [0.537] 27122
Elo difference: 2.6 +/- 3.1, LOS: 94.8 %, DrawRatio: 42.3 %
```