### PR TITLE
Add prefetch for TT values

### DIFF
--- a/engine/prefetcher.go
+++ b/engine/prefetcher.go
@@ -1,0 +1,6 @@
+//go:build !amd64
+// +build !amd64
+
+package engine
+
+func (c *Cache) Prefetch(hash uint64) {}

--- a/engine/prefetcher_amd64.go
+++ b/engine/prefetcher_amd64.go
@@ -1,0 +1,17 @@
+//go:build amd64
+// +build amd64
+
+package engine
+
+import (
+	"unsafe"
+)
+
+func _prefetch(item unsafe.Pointer)
+
+func (c *Cache) Prefetch(hash uint64) {
+	index := c.index(hash)
+	p := unsafe.Pointer(&c.items[index])
+
+	_prefetch(p)
+}

--- a/engine/prefetcher_amd64.s
+++ b/engine/prefetcher_amd64.s
@@ -1,0 +1,4 @@
+TEXT ·_prefetch(SB), $0-8
+       MOVQ       e+0(FP), AX
+       PREFETCHNTA (AX)
+       RET

--- a/search/search.go
+++ b/search/search.go
@@ -206,6 +206,7 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 	isPvNode := alpha != beta-1
 
 	position := e.Position
+	e.TranspositionTable.Prefetch(position.Hash())
 
 	currentMove := e.positionMoves[searchHeight]
 	// Position is drawn


### PR DESCRIPTION
```
Score of zahak_next vs zahak_master: 3435 - 3354 - 5858  [0.503] 12647
...      zahak_next playing White: 2093 - 1337 - 2893  [0.560] 6323
...      zahak_next playing Black: 1342 - 2017 - 2965  [0.447] 6324
...      White vs Black: 4110 - 2679 - 5858  [0.557] 12647
Elo difference: 2.2 +/- 4.4, LOS: 83.7 %, DrawRatio: 46.3 %
SPRT: llr -0.605 (-20.5%), lbound -2.94, ubound 2.94
```