### PR TITLE
Tweak RFP

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -300,10 +300,10 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 		}
 
 		// Reverse Futility Pruning
-		reverseFutilityMargin := int16(depthLeft) * p //(b - p)
-		if improving {
-			reverseFutilityMargin += p // int16(depthLeft) * p
-		}
+		reverseFutilityMargin := int16(depthLeft) * 85 //(b - p)
+		// if improving {
+		// 	reverseFutilityMargin += 110 // int16(depthLeft) * p
+		// }
 		if depthLeft < 8 && eval-reverseFutilityMargin >= beta {
 			e.info.rfpCounter += 1
 			return eval - reverseFutilityMargin /* fail soft */


### PR DESCRIPTION
```
Score of zahak_next vs zahak_master: 936 - 773 - 1535  [0.525] 3244
...      zahak_next playing White: 552 - 307 - 762  [0.576] 1621
...      zahak_next playing Black: 384 - 466 - 773  [0.475] 1623
...      White vs Black: 1018 - 691 - 1535  [0.550] 3244
Elo difference: 17.5 +/- 8.7, LOS: 100.0 %, DrawRatio: 47.3 %
SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted
Finished match
```