### PR TITLE
Tweaking probcut and singular extension

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -389,7 +389,7 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 
 		// Prob cut
 		// The idea is basically cherry picked from multiple engines, Weiss, Ethereal and Berserk for example
-		probBeta := min16(beta+110, WIN_IN_MAX)
+		probBeta := min16(beta+120, WIN_IN_MAX)
 		if depthLeft > 4 && abs16(beta) < WIN_IN_MAX && !(ttHit && nDepth >= depthLeft-3 && nEval < probBeta) {
 
 			hashMove := EmptyMove
@@ -487,11 +487,11 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 			}
 			// Singular Extension
 			var extension int8
-			if depthLeft > 8 &&
+			if depthLeft >= 8 &&
 				hashmove == nHashMove &&
 				ttHit &&
 				e.skipMove == EmptyMove &&
-				nDepth > depthLeft-3 &&
+				nDepth >= depthLeft-3 &&
 				nType != UpperBound &&
 				!position.IsInCheck() && // Check moves are automatically extended
 				abs16(nEval) < WIN_IN_MAX &&
@@ -501,13 +501,13 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 				position.UnMakeMove(hashmove, oldTag, oldEnPassant, hc)
 
 				// Search to reduced depth with a zero window a bit lower than ttScore
-				threshold := max16(nEval-2*int16(depthLeft), -CHECKMATE_EVAL)
+				threshold := max16(nEval-3*int16(depthLeft)/2, -CHECKMATE_EVAL)
 
 				e.skipMove = hashmove
 				e.skipHeight = searchHeight
 				e.innerLines[searchHeight].Recycle()
 				e.MovePickers[searchHeight] = e.TempMovePicker
-				score := e.alphaBeta(depthLeft/2-1, searchHeight, threshold-1, threshold)
+				score := e.alphaBeta((depthLeft-1)/2, searchHeight, threshold-1, threshold)
 				e.MovePickers[searchHeight] = movePicker
 				e.innerLines[searchHeight].Recycle()
 				e.skipMove = EmptyMove


### PR DESCRIPTION
STC:
http://chess.grantnet.us/test/20170/

```
ELO   | 4.67 +- 3.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.94 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 18544 W: 5288 L: 5039 D: 8217
```

LTC:

http://chess.grantnet.us/test/20171/
```
ELO   | 14.94 +- 7.58 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.04 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 3560 W: 863 L: 710 D: 1987
```