### PR TITLE
Tweak null move pruning

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -373,19 +373,19 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 			// 	R = min8(R, depthLeft-1)
 			// }
 
-			// if R >= 2 {
-			ep := position.MakeNullMove()
-			e.pred.Push(position.Hash())
-			e.innerLines[searchHeight+1].Recycle()
-			e.positionMoves[searchHeight+1] = EmptyMove
-			score := -e.alphaBeta(depthLeft-R, searchHeight+1, -beta, -beta+1)
-			e.pred.Pop()
-			position.UnMakeNullMove(ep)
-			if score >= beta {
-				e.info.nullMoveCounter += 1
-				return score
+			if R >= 2 {
+				ep := position.MakeNullMove()
+				e.pred.Push(position.Hash())
+				e.innerLines[searchHeight+1].Recycle()
+				e.positionMoves[searchHeight+1] = EmptyMove
+				score := -e.alphaBeta(depthLeft-R, searchHeight+1, -beta, -beta+1)
+				e.pred.Pop()
+				position.UnMakeNullMove(ep)
+				if score >= beta {
+					e.info.nullMoveCounter += 1
+					return score
+				}
 			}
-			// }
 		}
 
 		// Prob cut


### PR DESCRIPTION
STC:

http://chess.grantnet.us/test/20179/
```
ELO   | 8.13 +- 5.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 8080 W: 2342 L: 2153 D: 3585
```