### PR TITLE
Add value range reduction

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -696,6 +696,7 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 					LMR -= 1
 				}
 
+				// Credit to Ofek Shochat
 				if rangeReduction > 3 {
 					LMR += 1
 				}


### PR DESCRIPTION
Credit to Ofek Shochat

STC:
http://chess.grantnet.us/test/20503/

```
ELO   | 6.32 +- 4.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.08 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 11872 W: 3390 L: 3174 D: 5308
```

LTC:
http://chess.grantnet.us/test/20504/

```
ELO   | 5.19 +- 3.90 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 12720 W: 2754 L: 2564 D: 7402
```