### PR TITLE
Squeeze SEE pruning

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -649,7 +649,7 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 
 			// SEE pruning
 			if isCaptureMove && seeScores[noisyMoves] < 0 &&
-				depthLeft <= 3 && eval <= alpha && abs16(alpha) < WIN_IN_MAX {
+				depthLeft <= 4 && eval <= alpha && abs16(alpha) < WIN_IN_MAX {
 				e.info.seeCounter += 1
 				break
 			}


### PR DESCRIPTION
STC:
http://chess.grantnet.us/test/20522/
```
ELO   | 4.57 +- 3.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 18760 W: 5207 L: 4960 D: 8593

```

LTC:
http://chess.grantnet.us/test/20521/
```
ELO   | 8.64 +- 5.49 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 6432 W: 1426 L: 1266 D: 3740
```