### PR TITLE
Add history bonus for TT cutoffs

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -269,6 +269,7 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 	if !isPvNode && ttHit && nDepth >= depthLeft && !firstLayerOfSingularity {
 		if nEval >= beta && nType == LowerBound {
 			e.CacheHit()
+			e.AddHistory(nHashMove, currentMove, nHashMove.MovingPiece(), nHashMove.Destination(), depthLeft, searchHeight, -1)
 			return nEval
 		}
 		if nEval <= alpha && nType == UpperBound {


### PR DESCRIPTION
STC:

http://chess.grantnet.us/test/20716/
```
ELO   | 12.14 +- 7.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 4840 W: 1399 L: 1230 D: 2211
```

LTC:
http://chess.grantnet.us/test/20717/
```
ELO   | 7.44 +- 4.94 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 7656 W: 1625 L: 1461 D: 4570
```