### PR TITLE
Prune moves in move loop, even if in check

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -607,7 +607,7 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 		}
 		isKiller := movePicker.killer1 == move || movePicker.killer2 == move || movePicker.counterMove == move
 
-		if !isInCheck && e.doPruning && !isRootNode && bestscore > -WIN_IN_MAX {
+		if e.doPruning && !isRootNode && bestscore > -WIN_IN_MAX {
 
 			if depthLeft < 8 && isQuiet && !isKiller && fpMargin <= alpha && abs16(alpha) < WIN_IN_MAX {
 				e.info.efpCounter += 1


### PR DESCRIPTION
STC: http://chess.grantnet.us/test/21627/

```
ELO   | 6.40 +- 4.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 10048 W: 2365 L: 2180 D: 5503
```