### PR TITLE
Fix go mate finder

### DIFF
--- a/uci/uci.go
+++ b/uci/uci.go
@@ -299,7 +299,7 @@ func (uci *UCI) findMove(game Game, depth int8, ply uint16, cmd string) {
 			tm := NewTimeManager(time.Now(), int64(timeToThink), perMove, int64(inc), int64(movesToGo), pondering)
 			uci.runner.AddTimeManager(tm)
 		}
-		go uci.runner.Search(depth, int16(mateIn), int64(nodes))
+		go uci.runner.Search(depth, 2*int16(mateIn), int64(nodes))
 	} else {
 		tm := NewTimeManager(time.Now(), MAX_TIME, false, 0, 0, pondering)
 		uci.runner.AddTimeManager(tm)


### PR DESCRIPTION
STC: http://chess.grantnet.us/test/22224/

Against 8.4-dev:

```
ELO   | 67.91 +- 13.65 (95%)
CONF  | 40.0+0.40s Threads=1 Hash=64MB
GAMES | N: 1000 W: 299 L: 106 D: 595
```