### PR TITLE
Stop search only IF multi-pv is not set

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -825,7 +825,7 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 			TranspositionTable.Set(hash, hashmove, evalToTT(bestscore, searchHeight), depthLeft, UpperBound, e.Ply)
 		}
 	}
-	if e.isMainThread && isRootNode && legalMoves == 1 && len(e.MovesToSearch) == 0 {
+	if e.isMainThread && isRootNode && legalMoves == 1 && len(e.MovesToSearch) == 0 && e.MultiPV == 1 {
 		e.TimeManager().StopSearchNow = true
 	} else if e.isMainThread && isRootNode && !searchedAMove {
 		e.NoMoves = true


### PR DESCRIPTION
Most of the time when multi-pv is set it is because we want to analyze, not because we are in game.
Therefore making sure we don't exit the search early and evalute the position is the key for a good analysis

STC: http://chess.grantnet.us/test/23618/

```
ELO   | 2.61 +- 4.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 10632 W: 2210 L: 2130 D: 6292
```