### PR TITLE
Use tt-eval for pruning

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -382,6 +382,11 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 	}
 
 	if pruningAllowed {
+		if ttHit && ((nEval > eval && nType == LowerBound) ||
+			(nEval < eval && nType == UpperBound)) {
+			eval = nEval
+		}
+
 		// Razoring
 		if depthLeft < 2 && eval+350 <= alpha {
 			newEval := e.quiescence(alpha, beta, searchHeight)


### PR DESCRIPTION
STC:

```
ELO   | 10.43 +- 6.01 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 5096 W: 1090 L: 937 D: 3069
```