### PR TITLE
Tweak threat-pruning

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -428,10 +428,10 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 		}
 
 		// Threat pruning, idea from Koivisto
-		tpMargin := int16(0)
-		if improving {
-			tpMargin = 30
-		}
+		tpMargin := int16(30)
+		// if improving {
+		// 	tpMargin += 30
+		// }
 		if depthLeft == 1 && eval > beta+tpMargin && (!position.Board.HasThreats(position.Turn().Other()) || position.Board.HasThreats(position.Turn())) {
 			return beta
 		}


### PR DESCRIPTION
STC:

http://chess.grantnet.us/test/24015/

```
ELO   | 2.77 +- 2.20 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 37888 W: 7658 L: 7356 D: 22874
```

LTC:

http://chess.grantnet.us/test/24022/

```
ELO   | 3.15 +- 2.47 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 21952 W: 3288 L: 3089 D: 15575
```