### PR TITLE
See pruning 2

### DIFF
--- a/engine/eval_utils.go
+++ b/engine/eval_utils.go
@@ -41,6 +41,10 @@ func (b *Bitboard) getLeastValuablePiece(attacks uint64, color Color) (uint64, P
 }
 
 func (b *Bitboard) StaticExchangeEval(toSq Square, target Piece, frSq Square, aPiece Piece) int16 {
+	return b.SeeGe(toSq, target, frSq, aPiece, 0)
+}
+
+func (b *Bitboard) SeeGe(toSq Square, target Piece, frSq Square, aPiece Piece, bound int16) int16 {
 
 	gain := make([]int16, 32)
 	d := 0
@@ -64,7 +68,7 @@ func (b *Bitboard) StaticExchangeEval(toSq Square, target Piece, frSq Square, aP
 		d++ // next depth and side
 		color := aPiece.Color()
 		gain[d] = aPiece.seeWeight() - gain[d-1] // speculative store, if defended
-		if max(-gain[d-1], gain[d]) < 0 {
+		if max(-gain[d-1], gain[d]) < bound {
 			break // pruning does not influence the result
 		}
 		attacks ^= fromSet  // reset bit in set to traverse

--- a/search/movepicker.go
+++ b/search/movepicker.go
@@ -175,14 +175,14 @@ func (mp *MovePicker) scoreCaptureMoves() int {
 				// SEE for ordering
 				gain := int32(board.SeeGe(dest, capPiece, source, piece, -50*int16(mp.currentDepth)))
 				if gain < 0 {
-					scores[i] = -90_000_000 + gain
+					scores[i] = /* -90_000_000 + */ gain
 				} else if gain == 0 {
-					scores[i] = 100_000_000 + int32(capPiece.Weight()-piece.Weight())
+					scores[i] = /* 100_000_000 + */ int32(capPiece.Weight() - piece.Weight())
 				} else {
-					scores[i] = 100_100_000 + gain
+					scores[i] = /* 100_100_000 + */ gain
 				}
 			} else {
-				scores[i] = 100_100_000 + int32(capPiece.Weight()-piece.Weight())
+				scores[i] = /* 100_100_000 + */ int32(capPiece.Weight() - piece.Weight())
 			}
 			goto end
 		}

--- a/search/movepicker.go
+++ b/search/movepicker.go
@@ -173,7 +173,7 @@ func (mp *MovePicker) scoreCaptureMoves() int {
 				scores[i] = 150_000_000 + int32(p.Weight()+capPiece.Weight())
 			} else if !move.IsEnPassant() {
 				// SEE for ordering
-				gain := int32(board.SeeGe(dest, capPiece, source, piece, 50*int16(mp.currentDepth)))
+				gain := int32(board.SeeGe(dest, capPiece, source, piece, -50*int16(mp.currentDepth)))
 				if gain < 0 {
 					scores[i] = -90_000_000 + gain
 				} else if gain == 0 {

--- a/search/movepicker.go
+++ b/search/movepicker.go
@@ -20,6 +20,7 @@ type MovePicker struct {
 	killer2         Move
 	killerIndex     int
 	counterMove     Move
+	currentDepth    int8
 }
 
 func EmptyMovePicker() *MovePicker {
@@ -42,7 +43,7 @@ func EmptyMovePicker() *MovePicker {
 	return mp
 }
 
-func (mp *MovePicker) RecycleWith(p *Position, e *Engine, searchHeight int8, hashmove Move, isQuiescence bool) {
+func (mp *MovePicker) RecycleWith(p *Position, e *Engine, searchHeight int8, hashmove Move, currentDepth int8, isQuiescence bool) {
 	mp.engine = e
 	mp.position = p
 	mp.searchHeight = searchHeight
@@ -71,6 +72,7 @@ func (mp *MovePicker) RecycleWith(p *Position, e *Engine, searchHeight int8, has
 	mp.captureMoveList.Size = 0
 	mp.captureMoveList.Next = nextCapture
 	mp.captureMoveList.IsScored = false
+	mp.currentDepth = currentDepth
 
 	if !isQuiescence {
 		mp.killer1, mp.killer2 = mp.engine.searchHistory.KillerMoveAt(searchHeight)
@@ -171,7 +173,7 @@ func (mp *MovePicker) scoreCaptureMoves() int {
 				scores[i] = 150_000_000 + int32(p.Weight()+capPiece.Weight())
 			} else if !move.IsEnPassant() {
 				// SEE for ordering
-				gain := int32(board.StaticExchangeEval(dest, capPiece, source, piece))
+				gain := int32(board.SeeGe(dest, capPiece, source, piece, 50*int16(mp.currentDepth)))
 				if gain < 0 {
 					scores[i] = -90_000_000 + gain
 				} else if gain == 0 {

--- a/search/movepicker_test.go
+++ b/search/movepicker_test.go
@@ -36,6 +36,7 @@ func TestMovepickerNextWithQuietHashmove(t *testing.T) {
 		EmptyMove,
 		1,
 		EmptyMove,
+		0,
 	}
 
 	expectedOrder := []Move{10, 20, 18, 17, 16, 15, 14, 13, 12, 11, 9, 8, 7, 6, 5, 4, 3, 2, 1, 19}
@@ -77,6 +78,7 @@ func TestMovepickerNextWithCaptureHashmove(t *testing.T) {
 		EmptyMove,
 		1,
 		EmptyMove,
+		0,
 	}
 
 	expectedOrder := []Move{capture, 20, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 19}
@@ -124,6 +126,7 @@ func TestMovepickerNextWithNoHashmove(t *testing.T) {
 		EmptyMove,
 		1,
 		EmptyMove,
+		0,
 	}
 
 	expectedOrder := []Move{20, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 19}
@@ -157,7 +160,7 @@ func TestMovePickerNormalSearch(t *testing.T) {
 	engine.searchHistory.addKillerForTest(NewMove(B2, B4, WhitePawn, NoPiece, NoType, 0), 1)
 	engine.searchHistory.addHistoryForTest(NewMove(F1, C4, WhiteBishop, NoPiece, NoType, 0), 1)
 	engine.searchHistory.addHistoryForTest(NewMove(B2, B4, WhitePawn, NoPiece, NoType, 0), 1) // this is no-op
-	mp.RecycleWith(game.Position(), engine, 1, NewMove(A1, B1, WhiteRook, NoPiece, NoType, 0), false)
+	mp.RecycleWith(game.Position(), engine, 1, NewMove(A1, B1, WhiteRook, NoPiece, NoType, 0), 0, false)
 
 	moves := []Move{
 		NewMove(A1, B1, WhiteRook, NoPiece, NoType, 0),
@@ -229,7 +232,7 @@ func TestUpgradeMoveToHashmoveQuiet(t *testing.T) {
 	engine.searchHistory.addHistoryForTest(NewMove(F1, C4, WhiteBishop, NoPiece, NoType, 0), 1)
 	engine.searchHistory.addHistoryForTest(NewMove(B2, B4, WhitePawn, NoPiece, NoType, 0), 1) // this is no-op
 
-	mp.RecycleWith(game.Position(), engine, 1, EmptyMove, false)
+	mp.RecycleWith(game.Position(), engine, 1, EmptyMove, 0, false)
 
 	moves := []Move{
 		NewMove(A1, B1, WhiteRook, NoPiece, NoType, 0),
@@ -302,7 +305,7 @@ func TestMovePickerNormalSearchNoHashmove(t *testing.T) {
 	engine.searchHistory.addKillerForTest(NewMove(B2, B4, WhitePawn, NoPiece, NoType, 0), 1)
 	engine.searchHistory.addHistoryForTest(NewMove(F1, C4, WhiteBishop, NoPiece, NoType, 0), 1)
 	engine.searchHistory.addHistoryForTest(NewMove(B2, B4, WhitePawn, NoPiece, NoType, 0), 1) // this is no-op
-	mp.RecycleWith(game.Position(), engine, 1, EmptyMove, false)
+	mp.RecycleWith(game.Position(), engine, 1, EmptyMove, 0, false)
 
 	moves := []Move{
 		NewMove(E4, D5, WhitePawn, BlackPawn, NoType, Capture),
@@ -373,7 +376,7 @@ func TestMovePickerNormalSearchCaptureHashmove(t *testing.T) {
 	engine.searchHistory.addKillerForTest(NewMove(B2, B4, WhitePawn, NoPiece, NoType, 0), 1)
 	engine.searchHistory.addHistoryForTest(NewMove(F1, C4, WhiteBishop, NoPiece, NoType, 0), 1)
 	engine.searchHistory.addHistoryForTest(NewMove(B2, B4, WhitePawn, NoPiece, NoType, 0), 1) // this is no-op
-	mp.RecycleWith(game.Position(), engine, 1, NewMove(C3, D5, WhiteKnight, BlackPawn, NoType, Capture), false)
+	mp.RecycleWith(game.Position(), engine, 1, NewMove(C3, D5, WhiteKnight, BlackPawn, NoType, Capture), 0, false)
 
 	moves := []Move{
 		NewMove(C3, D5, WhiteKnight, BlackPawn, NoType, Capture),
@@ -445,7 +448,7 @@ func TestMovePickerNormalSearchUpgradeToHashmoveCapture(t *testing.T) {
 	engine.searchHistory.addKillerForTest(NewMove(B2, B4, WhitePawn, NoPiece, NoType, 0), 1)
 	engine.searchHistory.addHistoryForTest(NewMove(F1, C4, WhiteBishop, NoPiece, NoType, 0), 1)
 	engine.searchHistory.addHistoryForTest(NewMove(B2, B4, WhitePawn, NoPiece, NoType, 0), 1) // this is no-op
-	mp.RecycleWith(game.Position(), engine, 1, EmptyMove, false)
+	mp.RecycleWith(game.Position(), engine, 1, EmptyMove, 0, false)
 	mp.UpgradeToPvMove(NewMove(C3, D5, WhiteKnight, BlackPawn, NoType, Capture))
 
 	moves := []Move{
@@ -519,7 +522,7 @@ func TestMovePickerQuiescenceSearch(t *testing.T) {
 	engine.searchHistory.addKillerForTest(NewMove(B2, B4, WhitePawn, NoPiece, NoType, 0), 1)
 	engine.searchHistory.addHistoryForTest(NewMove(F1, C4, WhiteBishop, NoPiece, NoType, 0), 1)
 	engine.searchHistory.addHistoryForTest(NewMove(B2, B4, WhitePawn, NoPiece, NoType, 0), 1)
-	mp.RecycleWith(game.Position(), engine, 1, EmptyMove, true)
+	mp.RecycleWith(game.Position(), engine, 1, EmptyMove, 0, true)
 
 	moves := []Move{
 		NewMove(E4, D5, WhitePawn, BlackPawn, NoType, Capture),
@@ -551,7 +554,7 @@ func TestMovePickerNormalSearchWithPromotionNoHashmove(t *testing.T) {
 	engine := NewEngine(nil)
 	engine.Position = game.Position()
 	engine.ClearForSearch()
-	mp.RecycleWith(game.Position(), engine, 1, EmptyMove, false)
+	mp.RecycleWith(game.Position(), engine, 1, EmptyMove, 0, false)
 
 	moves := []Move{
 		NewMove(H7, G8, WhitePawn, BlackKnight, Queen, Capture),
@@ -597,7 +600,7 @@ func TestMovePickerNormalSearchWithPromotionPromotionQuietHashmove(t *testing.T)
 	engine := NewEngine(nil)
 	engine.Position = game.Position()
 	engine.ClearForSearch()
-	mp.RecycleWith(game.Position(), engine, 1, NewMove(H7, H8, WhitePawn, NoPiece, Knight, 0), false)
+	mp.RecycleWith(game.Position(), engine, 1, NewMove(H7, H8, WhitePawn, NoPiece, Knight, 0), 0, false)
 
 	moves := []Move{
 		NewMove(H7, H8, WhitePawn, NoPiece, Knight, 0),
@@ -643,7 +646,7 @@ func TestMovePickerNormalSearchWithPromotionPromotionCaptureHashmove(t *testing.
 	engine := NewEngine(nil)
 	engine.Position = game.Position()
 	engine.ClearForSearch()
-	mp.RecycleWith(game.Position(), engine, 1, NewMove(H7, G8, WhitePawn, BlackKnight, Knight, Capture), false)
+	mp.RecycleWith(game.Position(), engine, 1, NewMove(H7, G8, WhitePawn, BlackKnight, Knight, Capture), 0, false)
 
 	moves := []Move{
 		NewMove(H7, G8, WhitePawn, BlackKnight, Knight, Capture),
@@ -689,7 +692,7 @@ func TestMovePickerNormalSearchWithPromotionUpgradeToPromotionQuietHashmove(t *t
 	engine := NewEngine(nil)
 	engine.Position = game.Position()
 	engine.ClearForSearch()
-	mp.RecycleWith(game.Position(), engine, 1, EmptyMove, false)
+	mp.RecycleWith(game.Position(), engine, 1, EmptyMove, 0, false)
 	mp.UpgradeToPvMove(NewMove(H7, H8, WhitePawn, NoPiece, Knight, 0))
 
 	moves := []Move{
@@ -736,7 +739,7 @@ func TestMovePickerNormalSearchWithPromotionUpgradeToPromotionCaptureHashmove(t 
 	engine := NewEngine(nil)
 	engine.Position = game.Position()
 	engine.ClearForSearch()
-	mp.RecycleWith(game.Position(), engine, 1, EmptyMove, false)
+	mp.RecycleWith(game.Position(), engine, 1, EmptyMove, 0, false)
 	mp.UpgradeToPvMove(NewMove(H7, G8, WhitePawn, BlackKnight, Knight, Capture))
 
 	moves := []Move{

--- a/search/quiescence.go
+++ b/search/quiescence.go
@@ -122,7 +122,7 @@ func (e *Engine) quiescence(alpha int16, beta int16, searchHeight int8) int16 {
 		noisyMoves += 1
 		// }
 
-		if /* isCaptureMove && */ seeScores[noisyMoves] < 0 {
+		if /* isCaptureMove && */ seeScores[noisyMoves] < -50 {
 			// SEE pruning
 			break
 		}

--- a/search/quiescence.go
+++ b/search/quiescence.go
@@ -106,7 +106,7 @@ func (e *Engine) quiescence(alpha int16, beta int16, searchHeight int8) int16 {
 	originalAlpha := alpha
 
 	movePicker := e.MovePickers[searchHeight]
-	movePicker.RecycleWith(position, e, searchHeight, EmptyMove, true)
+	movePicker.RecycleWith(position, e, searchHeight, EmptyMove, 1, true)
 
 	noisyMoves := -1
 	seeScores := movePicker.captureMoveList.Scores

--- a/search/quiescence.go
+++ b/search/quiescence.go
@@ -106,7 +106,7 @@ func (e *Engine) quiescence(alpha int16, beta int16, searchHeight int8) int16 {
 	originalAlpha := alpha
 
 	movePicker := e.MovePickers[searchHeight]
-	movePicker.RecycleWith(position, e, searchHeight, EmptyMove, 1, true)
+	movePicker.RecycleWith(position, e, searchHeight, EmptyMove, 0, true)
 
 	noisyMoves := -1
 	seeScores := movePicker.captureMoveList.Scores
@@ -122,7 +122,7 @@ func (e *Engine) quiescence(alpha int16, beta int16, searchHeight int8) int16 {
 		noisyMoves += 1
 		// }
 
-		if /* isCaptureMove && */ seeScores[noisyMoves] < -50 {
+		if /* isCaptureMove && */ seeScores[noisyMoves] < 0 {
 			// SEE pruning
 			break
 		}

--- a/search/search.go
+++ b/search/search.go
@@ -695,8 +695,8 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 			}
 
 			// SEE pruning
-			if isCaptureMove && seeScores[noisyMoves] < 0 &&
-				depthLeft <= 4 && eval <= alpha && abs16(alpha) < WIN_IN_MAX {
+			if isCaptureMove && seeScores[noisyMoves] < -50*int32(depthLeft) &&
+				depthLeft < 7 && eval <= alpha && abs16(alpha) < WIN_IN_MAX {
 				break
 			}
 			//

--- a/search/search.go
+++ b/search/search.go
@@ -695,7 +695,7 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 			}
 
 			// SEE pruning
-			if isCaptureMove && seeScores[noisyMoves] < -50*int32(depthLeft) &&
+			if isCaptureMove && seeScores[noisyMoves] < -20*int32(depthLeft) &&
 				depthLeft < 7 && eval <= alpha && abs16(alpha) < WIN_IN_MAX {
 				break
 			}

--- a/search/search.go
+++ b/search/search.go
@@ -695,15 +695,15 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 			}
 
 			// SEE pruning
-			if isCaptureMove && seeScores[noisyMoves] < 0 &&
-				depthLeft <= 4 && eval <= alpha && abs16(alpha) < WIN_IN_MAX {
+			if isCaptureMove && seeScores[noisyMoves] < -50*int32(depthLeft) &&
+				depthLeft < 7 && eval <= alpha && abs16(alpha) < WIN_IN_MAX {
 				break
 			}
 
 			if isQuiet && depthLeft < 7 && !isKiller {
 				seeBound := -50 * int16(depthLeft)
 				if position.Board.SeeGe(move.Destination(), move.CapturedPiece(), move.Source(), move.MovingPiece(), seeBound) < seeBound {
-					continue // LMP
+					continue // Quiet SEE
 				}
 
 			}

--- a/search/search.go
+++ b/search/search.go
@@ -501,7 +501,7 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 	}
 
 	movePicker := e.MovePickers[searchHeight]
-	movePicker.RecycleWith(position, e, searchHeight, nHashMove, false)
+	movePicker.RecycleWith(position, e, searchHeight, nHashMove, depthLeft, false)
 	oldAlpha := alpha
 
 	// using fail soft with negamax:

--- a/search/search.go
+++ b/search/search.go
@@ -695,9 +695,17 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 			}
 
 			// SEE pruning
-			if isCaptureMove && seeScores[noisyMoves] < -20*int32(depthLeft) &&
-				depthLeft < 7 && eval <= alpha && abs16(alpha) < WIN_IN_MAX {
+			if isCaptureMove && seeScores[noisyMoves] < 0 &&
+				depthLeft <= 4 && eval <= alpha && abs16(alpha) < WIN_IN_MAX {
 				break
+			}
+
+			if isQuiet && depthLeft < 7 && !isKiller {
+				seeBound := -50 * int16(depthLeft)
+				if position.Board.SeeGe(move.Destination(), move.CapturedPiece(), move.Source(), move.MovingPiece(), seeBound) < seeBound {
+					continue // LMP
+				}
+
 			}
 			//
 			// // History pruning


### PR DESCRIPTION
Quiet SEE vs master (STC): http://chess.grantnet.us/test/24074/
```
ELO   | 6.30 +- 4.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 9488 W: 1990 L: 1818 D: 5680
```

Tweaked Noisy SEE vs the above (STC): http://chess.grantnet.us/test/24078/
```
ELO   | 2.93 +- 2.35 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 32648 W: 6479 L: 6204 D: 19965
```

The above vs master (LTC): http://chess.grantnet.us/test/24080/ 

```
ELO   | 2.38 +- 1.91 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 37616 W: 5708 L: 5450 D: 26458
```