### PR TITLE
Apply Capture history on all tactical moves

### DIFF
--- a/search/movepicker.go
+++ b/search/movepicker.go
@@ -180,13 +180,13 @@ func (mp *MovePicker) scoreCaptureMoves() int {
 			piece := move.MovingPiece()
 			if promoType != NoType {
 				p := GetPiece(promoType, White)
-				scores[i] = history + 150_000_000 + int32(p.Weight()+capPiece.Weight())
+				scores[i] = history + 2000 + int32(p.Weight()+capPiece.Weight())
 			} else if !move.IsEnPassant() {
 				// SEE for ordering
 				gain := int32(board.SeeGe(dest, capPiece, source, piece, -50*int16(mp.currentDepth)))
 				mp.captureSees[i] = gain
 				if gain < 0 {
-					scores[i] = /* -90_000_000 + */ gain
+					scores[i] = history + /* -90_000_000 + */ gain
 				} else if gain == 0 {
 					scores[i] = history + /* 100_000_000 + */ int32(capPiece.Weight()-piece.Weight())
 				} else {
@@ -200,7 +200,7 @@ func (mp *MovePicker) scoreCaptureMoves() int {
 
 		if promoType != NoType {
 			p := GetPiece(promoType, White)
-			scores[i] = history + 150_000_000 + int32(p.Weight())
+			scores[i] = history + 2000 + int32(p.Weight())
 			goto end
 		}
 


### PR DESCRIPTION
STC: http://chess.grantnet.us/test/24141/

```
ELO   | 1.97 +- 2.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 42632 W: 8381 L: 8139 D: 26112
```

LTC: http://chess.grantnet.us/test/24145/

```
ELO   | 2.73 +- 2.50 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.99 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 20968 W: 3049 L: 2884 D: 15035
```