### PR TITLE
Fix int overflow in LMP

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -636,7 +636,8 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 			return 0
 		}
 	}
-	pruningThreashold := int(5 + depthLeft*depthLeft)
+	d := int(depthLeft)
+	pruningThreashold := 5 + d*d
 	if !improving && !isPvNode {
 		pruningThreashold = pruningThreashold/2 - 1
 	}


### PR DESCRIPTION
STC: http://chess.grantnet.us/test/24163/

```
ELO   | 1.06 +- 3.24 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 17032 W: 3312 L: 3260 D: 10460
```