### PR TITLE
More search tweaks

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -13,13 +13,13 @@ import (
 const TB_WIN_BOUND int16 = 27000
 const TB_LOSS_BOUND int16 = -27000
 
-var RazoringMargin int16 = 339
-var TPMargin int16 = 35
-var RFPMargin int16 = 64
-var FPMargin int16 = 97
-var RangeReductionMargin int16 = 74
-var DeltaMargin int16 = 345
-var LMRCaptureMargin int16 = 84
+var RazoringMargin int16 = 220
+var TPMargin int16 = 150
+var RFPMargin int16 = 53
+var FPMargin int16 = 143
+var RangeReductionMargin int16 = 38
+var DeltaMargin int16 = 296
+var LMRCaptureMargin int16 = 189
 
 func (r *Runner) Search(depth int8, mateIn int16, nodes int64) {
 	e := r.Engines[0]

--- a/search/search.go
+++ b/search/search.go
@@ -13,13 +13,13 @@ import (
 const TB_WIN_BOUND int16 = 27000
 const TB_LOSS_BOUND int16 = -27000
 
-var RazoringMargin int16 = 220
-var TPMargin int16 = 150
-var RFPMargin int16 = 53
-var FPMargin int16 = 143
-var RangeReductionMargin int16 = 38
-var DeltaMargin int16 = 296
-var LMRCaptureMargin int16 = 189
+var RazoringMargin int16 = 245
+var TPMargin int16 = 151
+var RFPMargin int16 = 54
+var FPMargin int16 = 149
+var RangeReductionMargin int16 = 44
+var DeltaMargin int16 = 310
+var LMRCaptureMargin int16 = 151
 
 func (r *Runner) Search(depth int8, mateIn int16, nodes int64) {
 	e := r.Engines[0]


### PR DESCRIPTION
STC:

http://chess.grantnet.us/test/24496/
```
ELO   | 3.17 +- 2.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 26432 W: 5013 L: 4772 D: 16647
```

LTC (running):

http://chess.grantnet.us/test/24635/