### PR TITLE
SMP scaling: Limit the use of pointers

### DIFF
--- a/engine/bitboard.go
+++ b/engine/bitboard.go
@@ -380,8 +380,8 @@ func (b *Bitboard) Draw() string {
 	return s
 }
 
-func (b *Bitboard) copy() *Bitboard {
-	return &Bitboard{
+func (b *Bitboard) copy() Bitboard {
+	return Bitboard{
 		b.blackPawn,
 		b.blackKnight,
 		b.blackBishop,

--- a/engine/fen.go
+++ b/engine/fen.go
@@ -79,8 +79,8 @@ func (g *Game) Fen() string {
 	return fen
 }
 
-func bitboardFromFen(fen string) *Bitboard {
-	board := &Bitboard{}
+func bitboardFromFen(fen string) Bitboard {
+	board := Bitboard{}
 	ranks := []Square{A8, A7, A6, A5, A4, A3, A2, A1}
 	rank := 0
 	bitboardIndex := A8
@@ -122,7 +122,7 @@ func positionFromFen(fen string) Position {
 	p := Position{
 		bitboardFromFen(fen),
 		NewNetworkState(),
-		&newUpdates,
+		newUpdates,
 		NoSquare,
 		0,
 		0,
@@ -169,7 +169,7 @@ func positionFromFen(fen string) Position {
 	} else if ok {
 		p.EnPassant = sq
 	}
-	if isInCheck(p.Board, p.Turn()) {
+	if isInCheck(&p.Board, p.Turn()) {
 		p.SetTag(InCheck)
 	}
 

--- a/engine/movegen.go
+++ b/engine/movegen.go
@@ -13,7 +13,7 @@ func (p *Position) IsPseudoLegal(move Move) bool {
 	dest := move.Destination()
 	srcMask := SquareMask[src]
 	destMask := SquareMask[dest]
-	board := p.Board
+	board := &p.Board
 	var ownPieces, enemyPieces, enemyKing, enemyPawns uint64
 	var canQueenSideCastle, canKingSideCastle bool
 	var queenSideRookSquare, kingSideRookSquare Square
@@ -124,15 +124,15 @@ func (p *Position) IsPseudoLegal(move Move) bool {
 func (p *Position) PseudoLegalMoves() []Move {
 	ml := NewMoveList(500)
 
-	p.GetCaptureMoves(ml)
-	p.GetQuietMoves(ml)
+	p.GetCaptureMoves(&ml)
+	p.GetQuietMoves(&ml)
 
 	return ml.Moves[:ml.Size]
 }
 
 func (p *Position) GetQuietMoves(ml *MoveList) {
 	color := p.Turn()
-	board := p.Board
+	board := &p.Board
 
 	var taboo uint64
 

--- a/engine/movegen_test.go
+++ b/engine/movegen_test.go
@@ -9,8 +9,8 @@ func TestBishopMoves(t *testing.T) {
 	fen := "rnbqkbnr/pPp1pppp/4P3/3pP3/3p4/4B1N1/PP2BPPP/1NRQK2R w Kkq - 0 1"
 	g := FromFen(fen)
 	ml := NewMoveList(13)
-	g.position.slidingQuietMoves(White, Bishop, ml)
-	g.position.slidingCaptureMoves(White, Bishop, ml)
+	g.position.slidingQuietMoves(White, Bishop, &ml)
+	g.position.slidingCaptureMoves(White, Bishop, &ml)
 	moves := ml.Moves
 	expectedMoves := []Move{
 		NewMove(E2, F1, WhiteBishop, NoPiece, NoType, 0),
@@ -46,8 +46,8 @@ func TestRookMoves(t *testing.T) {
 	fen := "rnkqbbnr/ppp1pppp/4P3/3pP3/3P4/4B1N1/PP2BPPP/1NRQK2R w Kkq - 0 1"
 	g := FromFen(fen)
 	ml := NewMoveList(8)
-	g.position.slidingQuietMoves(White, Rook, ml)
-	g.position.slidingCaptureMoves(White, Rook, ml)
+	g.position.slidingQuietMoves(White, Rook, &ml)
+	g.position.slidingCaptureMoves(White, Rook, &ml)
 	moves := ml.Moves
 	expectedMoves := []Move{
 		NewMove(H1, G1, WhiteRook, NoPiece, NoType, 0),
@@ -78,8 +78,8 @@ func TestQueenMoves(t *testing.T) {
 	fen := "rnbqkbnr/pPp1pppp/4P3/3pP3/3p4/4B1N1/PP2BPPP/1NRQK2R w Kkq - 0 1"
 	g := FromFen(fen)
 	ml := NewMoveList(6)
-	g.position.slidingCaptureMoves(White, Queen, ml)
-	g.position.slidingQuietMoves(White, Queen, ml)
+	g.position.slidingCaptureMoves(White, Queen, &ml)
+	g.position.slidingQuietMoves(White, Queen, &ml)
 	moves := ml.Moves
 	expectedMoves := []Move{
 		NewMove(D1, D2, WhiteQueen, NoPiece, NoType, 0),
@@ -110,9 +110,9 @@ func TestKingMoves(t *testing.T) {
 	board := g.position.Board
 	color := White
 	ml := NewMoveList(3)
-	taboo := tabooSquares(board, color)
-	g.position.kingCaptureMoves(color, ml)
-	g.position.kingQuietMoves(taboo, color, ml)
+	taboo := tabooSquares(&board, color)
+	g.position.kingCaptureMoves(color, &ml)
+	g.position.kingQuietMoves(taboo, color, &ml)
 	moves := ml.Moves
 	expectedMoves := []Move{
 		NewMove(E1, D2, WhiteKing, BlackRook, NoType, Capture),
@@ -139,10 +139,10 @@ func TestKingCastlingWithOccupiedSquares(t *testing.T) {
 	g := FromFen(fen)
 	board := g.position.Board
 	color := White
-	taboo := tabooSquares(board, color)
+	taboo := tabooSquares(&board, color)
 	ml := NewMoveList(3)
-	g.position.kingCaptureMoves(color, ml)
-	g.position.kingQuietMoves(taboo, color, ml)
+	g.position.kingCaptureMoves(color, &ml)
+	g.position.kingQuietMoves(taboo, color, &ml)
 	moves := ml.Moves
 	expectedMoves := []Move{
 		NewMove(E1, E2, WhiteKing, NoPiece, NoType, 0),
@@ -169,10 +169,10 @@ func TestKingQueenSideCastling(t *testing.T) {
 	g := FromFen(fen)
 	board := g.position.Board
 	color := White
-	taboo := tabooSquares(board, color)
+	taboo := tabooSquares(&board, color)
 	ml := NewMoveList(4)
-	g.position.kingCaptureMoves(color, ml)
-	g.position.kingQuietMoves(taboo, color, ml)
+	g.position.kingCaptureMoves(color, &ml)
+	g.position.kingQuietMoves(taboo, color, &ml)
 	moves := ml.Moves
 	expectedMoves := []Move{
 		NewMove(E1, E2, WhiteKing, NoPiece, NoType, 0),
@@ -200,8 +200,8 @@ func TestPawnMovesForWhite(t *testing.T) {
 	g := FromFen(fen)
 	ml := NewMoveList(18)
 	color := White
-	g.position.pawnQuietMoves(color, ml)
-	g.position.pawnCaptureMoves(color, ml)
+	g.position.pawnQuietMoves(color, &ml)
+	g.position.pawnCaptureMoves(color, &ml)
 	moves := ml.Moves
 	expectedMoves := []Move{
 		NewMove(H2, H4, WhitePawn, NoPiece, NoType, 0),
@@ -243,8 +243,8 @@ func TestPawnMovesForBlack(t *testing.T) {
 	g := FromFen(fen)
 	ml := NewMoveList(13)
 	color := Black
-	g.position.pawnQuietMoves(color, ml)
-	g.position.pawnCaptureMoves(color, ml)
+	g.position.pawnQuietMoves(color, &ml)
+	g.position.pawnCaptureMoves(color, &ml)
 	moves := ml.Moves
 	expectedMoves := []Move{
 		NewMove(H7, H6, BlackPawn, NoPiece, NoType, 0),
@@ -280,8 +280,8 @@ func TestKnightMoves(t *testing.T) {
 	fen := "rnbqkbn1/pPp1pppp/4P3/1N1pP3/3p4/4B1N1/PP1rBPPP/R3K2R w Kkq d6 0 1"
 	g := FromFen(fen)
 	ml := NewMoveList(10)
-	g.position.knightQuietMoves(White, ml)
-	g.position.knightCaptureMoves(White, ml)
+	g.position.knightQuietMoves(White, &ml)
+	g.position.knightCaptureMoves(White, &ml)
 	moves := ml.Moves
 	expectedMoves := []Move{
 		NewMove(G3, F1, WhiteKnight, NoPiece, NoType, 0),
@@ -339,9 +339,9 @@ func TestCastleAndPawnAttack(t *testing.T) {
 	board := g.position.Board
 	ml := NewMoveList(1)
 	color := White
-	taboo := tabooSquares(board, color)
-	g.position.kingCaptureMoves(color, ml)
-	g.position.kingQuietMoves(taboo, color, ml)
+	taboo := tabooSquares(&board, color)
+	g.position.kingCaptureMoves(color, &ml)
+	g.position.kingQuietMoves(taboo, color, &ml)
 	moves := ml.Moves
 	expectedMoves := []Move{
 		NewMove(E1, D1, WhiteKing, NoPiece, NoType, 0),

--- a/engine/movelist.go
+++ b/engine/movelist.go
@@ -8,8 +8,8 @@ type MoveList struct {
 	Next     int
 }
 
-func NewMoveList(capacity int) *MoveList {
-	return &MoveList{
+func NewMoveList(capacity int) MoveList {
+	return MoveList{
 		make([]Move, capacity),
 		make([]int32, capacity),
 		false,

--- a/engine/nnue.go
+++ b/engine/nnue.go
@@ -91,7 +91,7 @@ type NetworkState struct {
 	OutputBias        float32
 }
 
-func NewNetworkState() *NetworkState {
+func NewNetworkState() NetworkState {
 	net := NetworkState{
 		HiddenWeights: CurrentHiddenWeights,
 		HiddenBiases:  CurrentHiddenBiases,
@@ -104,7 +104,7 @@ func NewNetworkState() *NetworkState {
 	for i := 0; i < MaximumDepth; i++ {
 		net.HiddenOutputs[i] = make([]float32, NetHiddenSize)
 	}
-	return &net
+	return net
 }
 
 const Remove int8 = -1

--- a/engine/position.go
+++ b/engine/position.go
@@ -13,9 +13,9 @@ var phaseValues = []int{0, 1, 1, 2, 4, 0, 0, 1, 1, 2, 4, 0}
 var maxPhase int = 24
 
 type Position struct {
-	Board         *Bitboard
-	Net           *NetworkState
-	Updates       *Updates
+	Board         Bitboard
+	Net           NetworkState
+	Updates       Updates
 	EnPassant     Square
 	Tag           PositionTag
 	hash          uint64
@@ -66,7 +66,7 @@ func (p *Position) MakeNullMove() Square {
 	} else {
 		p.Updates.Add(768, Remove)
 	}
-	p.Net.UpdateHidden(p.Updates)
+	p.Net.UpdateHidden(&p.Updates)
 	return ep
 }
 
@@ -279,7 +279,7 @@ func (p *Position) makeMoveHelper(move Move, updateHidden bool) (Square, Positio
 		p.ClearTag(WhiteCanCastleKingSide)
 	}
 
-	if isInCheck(p.Board, p.Turn()) { // Is the move legal (bad way to determine legality
+	if isInCheck(&p.Board, p.Turn()) { // Is the move legal (bad way to determine legality
 		p.unMakeMoveHelper(move, tag, ep, hc, false)
 		return NoSquare, 0, 0, false
 	}
@@ -288,7 +288,7 @@ func (p *Position) makeMoveHelper(move Move, updateHidden bool) (Square, Positio
 	p.ToggleTurn()
 
 	// Set check tag
-	if isInCheck(p.Board, p.Turn()) {
+	if isInCheck(&p.Board, p.Turn()) {
 		p.SetTag(InCheck)
 	} else {
 		p.ClearTag(InCheck)
@@ -302,7 +302,7 @@ func (p *Position) makeMoveHelper(move Move, updateHidden bool) (Square, Positio
 
 	if updateHidden {
 		p.hashAcc[p.hashHeight] = p.hash
-		p.Net.UpdateHidden(p.Updates)
+		p.Net.UpdateHidden(&p.Updates)
 		p.hashHeight += 1
 	}
 
@@ -504,7 +504,7 @@ func (p *Position) Copy() *Position {
 	newPos := &Position{
 		p.Board.copy(),
 		NewNetworkState(),
-		&newUpdates,
+		newUpdates,
 		p.EnPassant,
 		p.Tag,
 		p.hash,

--- a/search/movepicker.go
+++ b/search/movepicker.go
@@ -10,8 +10,8 @@ type MovePicker struct {
 	position        *Position
 	engine          *Engine
 	hashmove        Move
-	quietMoveList   *MoveList
-	captureMoveList *MoveList
+	quietMoveList   MoveList
+	captureMoveList MoveList
 	captureSees     []int32
 	searchHeight    int8
 	currentMove     Move
@@ -104,14 +104,14 @@ func (mp *MovePicker) generateQuietMoves() {
 	if mp.isQuiescence || !mp.quietMoveList.IsEmpty() {
 		return
 	}
-	mp.position.GetQuietMoves(mp.quietMoveList)
+	mp.position.GetQuietMoves(&mp.quietMoveList)
 }
 
 func (mp *MovePicker) generateCaptureMoves() {
 	if !mp.captureMoveList.IsEmpty() || !mp.quietMoveList.IsEmpty() {
 		return
 	}
-	mp.position.GetCaptureMoves(mp.captureMoveList)
+	mp.position.GetCaptureMoves(&mp.captureMoveList)
 }
 
 func (mp *MovePicker) HasNoPVMove() bool {

--- a/search/movepicker_test.go
+++ b/search/movepicker_test.go
@@ -15,14 +15,14 @@ func TestMovepickerNextWithQuietHashmove(t *testing.T) {
 		nil,
 		NewEngine(nil),
 		10,
-		&MoveList{
+		MoveList{
 			Moves:    []Move{10, 5, 4, 8, 3, 2, 1, 6, 7, 9},
 			Scores:   []int32{10000, 500, 400, 800, 300, 200, 100, 600, 700, 900},
 			IsScored: true,
 			Size:     10,
 			Next:     1,
 		},
-		&MoveList{
+		MoveList{
 			Moves:    []Move{20, 15, 14, 18, 13, 12, 11, 16, 17, 19},
 			Scores:   []int32{2000, 1500, 1400, 1800, 1300, 1200, 1100, 1600, 1700, -1900},
 			IsScored: true,
@@ -58,14 +58,14 @@ func TestMovepickerNextWithCaptureHashmove(t *testing.T) {
 		nil,
 		NewEngine(nil),
 		capture,
-		&MoveList{
+		MoveList{
 			Moves:    []Move{10, 5, 4, 8, 3, 2, 1, 6, 7, 9},
 			Scores:   []int32{1000, 500, 400, 800, 300, 200, 100, 600, 700, 900},
 			IsScored: true,
 			Size:     10,
 			Next:     0,
 		},
-		&MoveList{
+		MoveList{
 			Moves:    []Move{capture, 20, 15, 14, 13, 12, 11, 16, 17, 19},
 			Scores:   []int32{18000, 2000, 1500, 1400, 1300, 1200, 1100, 1600, 1700, -1900},
 			IsScored: true,
@@ -107,14 +107,14 @@ func TestMovepickerNextWithNoHashmove(t *testing.T) {
 		nil,
 		NewEngine(nil),
 		0,
-		&MoveList{
+		MoveList{
 			Moves:    []Move{10, 5, 4, 8, 3, 2, 1, 6, 7, 9},
 			Scores:   []int32{1000, 500, 400, 800, 300, 200, 100, 600, 700, 900},
 			IsScored: true,
 			Size:     10,
 			Next:     0,
 		},
-		&MoveList{
+		MoveList{
 			Moves:    []Move{20, 15, 14, 18, 13, 12, 11, 16, 17, 19},
 			Scores:   []int32{2000, 1500, 1400, 1800, 1300, 1200, 1100, 1600, 1700, -1900},
 			IsScored: true,


### PR DESCRIPTION
While not making much of difference in single-threaded mode:

STC: http://chess.grantnet.us/test/24652/

```
ELO   | -0.56 +- 1.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 46872 W: 8617 L: 8693 D: 29562
```

It makes for a much better scaling in SMP mode!

SMP: http://chess.grantnet.us/test/24651/

```
ELO   | 10.50 +- 3.81 (95%)
CONF  | 5.0+0.05s Threads=8 Hash=64MB
GAMES | N: 10000 W: 1723 L: 1421 D: 6856
```