### PR TITLE
Reduce less if NMP fails

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -343,6 +343,7 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 	if eval+p > beta {
 		histDepth += 1
 	}
+	var failedNMP bool
 
 	if pruningAllowed {
 		if ttHit && ((nEval > eval && nType == LowerBound) ||
@@ -368,6 +369,7 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 		// NullMove pruning
 		isNullMoveAllowed := currentMove != EmptyMove && !position.IsEndGame()
 		if isNullMoveAllowed && depthLeft >= 2 && eval > beta {
+			failedNMP = true
 			var R = 4 + min8(depthLeft/4, 3)
 			if eval >= beta+100 {
 				R += 1
@@ -723,6 +725,10 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 				}
 
 				if improving {
+					LMR -= 1
+				}
+
+				if failedNMP {
 					LMR -= 1
 				}
 


### PR DESCRIPTION
STC: http://chess.grantnet.us/test/24703/

```
ELO   | 3.42 +- 2.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 23376 W: 4487 L: 4257 D: 14632
```

LTC: http://chess.grantnet.us/test/24708/

```
ELO   | 7.57 +- 4.36 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 6424 W: 918 L: 778 D: 4728
```