### PR TITLE
SEE pruning tweaks

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -670,7 +670,7 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 				}
 			}
 
-			seeBound /= 2
+			seeBound = -35 * int16(depthLeft)
 			if isQuiet && depthLeft < 7 && !isKiller {
 				seeScore = position.Board.SeeGe(move.Destination(), move.CapturedPiece(), move.Source(), move.MovingPiece(), seeBound)
 				if seeScore < seeBound {

--- a/search/search.go
+++ b/search/search.go
@@ -670,6 +670,7 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 				}
 			}
 
+			seeBound /= 2
 			if isQuiet && depthLeft < 7 && !isKiller {
 				seeScore = position.Board.SeeGe(move.Destination(), move.CapturedPiece(), move.Source(), move.MovingPiece(), seeBound)
 				if seeScore < seeBound {

--- a/search/search.go
+++ b/search/search.go
@@ -671,7 +671,7 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 			}
 
 			seeBound = -35 * int16(depthLeft)
-			if isQuiet && depthLeft < 7 && !isKiller {
+			if isQuiet && depthLeft < 10 && !isKiller {
 				seeScore = position.Board.SeeGe(move.Destination(), move.CapturedPiece(), move.Source(), move.MovingPiece(), seeBound)
 				if seeScore < seeBound {
 					continue // Quiet SEE


### PR DESCRIPTION
STC (vs 225847d6de0613b2db104d526cf367e4a5dddb0f):

http://chess.grantnet.us/test/24800/

```
ELO   | 2.80 +- 2.23 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 34536 W: 6569 L: 6291 D: 21676
```

STC (225847d6de0613b2db104d526cf367e4a5dddb0f vs master):
http://chess.grantnet.us/test/24793/

```
ELO   | 1.98 +- 1.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 91816 W: 17156 L: 16633 D: 58027
```

LTC (vs master): http://chess.grantnet.us/test/24811/

```
ELO   | 4.31 +- 3.08 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 13064 W: 1830 L: 1668 D: 9566
```