### PR TITLE
LMR reduction for quiet moves when Hashmove is Noisy

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -619,6 +619,7 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 	// var historyThreashold int32 = int32(depthLeft) * -1024
 	var move Move
 	var seeScore int16
+	noisyHash := ttHit && (nHashMove.IsCapture() || nHashMove.PromoType() != NoType)
 	for true {
 
 		if isRootNode && e.isMainThread && bestscore-e.score >= -20 && e.TimeManager().ShouldStop() {
@@ -715,6 +716,10 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 
 				if isInCheck {
 					LMR -= 1
+				}
+
+				if noisyHash {
+					LMR += 1
 				}
 
 				if isKiller {

--- a/search/search.go
+++ b/search/search.go
@@ -707,6 +707,9 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 				if isQuiet {
 					LMR = int8(quietLmrReductions[min8(31, depthLeft)][min(31, legalMoves)])
 					LMR -= int8(e.searchHistory.QuietHistory(gpMove, currentMove, move) / 10649) //12288)
+					if noisyHash {
+						LMR += 1
+					}
 				} else {
 					LMR = int8(noisyLmrReductions[min8(31, depthLeft)][min(31, legalMoves)])
 					if eval+move.CapturedPiece().Weight()+LMRCaptureMargin < beta {
@@ -716,10 +719,6 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 
 				if isInCheck {
 					LMR -= 1
-				}
-
-				if noisyHash {
-					LMR += 1
 				}
 
 				if isKiller {


### PR DESCRIPTION
STC: http://chess.grantnet.us/test/24881/

```
ELO   | 3.37 +- 2.69 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 23224 W: 4317 L: 4092 D: 14815
```

LTC: http://chess.grantnet.us/test/24883/