### PR TITLE
Always apply multi-cut

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -546,7 +546,7 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 							e.skipMove = hashmove
 							e.innerLines[searchHeight].Recycle()
 							e.MovePickers[searchHeight] = e.TempMovePicker
-							score = e.alphaBeta((depthLeft+3)/2, searchHeight, beta-1, beta)
+							score = e.alphaBeta((depthLeft+5)/3, searchHeight, beta-1, beta)
 							e.MovePickers[searchHeight] = movePicker
 							e.innerLines[searchHeight].Recycle()
 							e.skipMove = EmptyMove

--- a/search/search.go
+++ b/search/search.go
@@ -552,7 +552,7 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 							e.skipMove = EmptyMove
 							e.skipHeight = MAX_DEPTH
 
-							if score >= beta {
+							if score >= beta+20 {
 								return beta
 							}
 						}

--- a/search/search.go
+++ b/search/search.go
@@ -538,23 +538,21 @@ func (e *Engine) alphaBeta(depthLeft int8, searchHeight int8, alpha int16, beta 
 				} else {
 
 					// Multi-Cut, at least 2 moves beat beta, idea is taken from Stockfish
-					if pruningAllowed {
-						if threshold >= beta {
-							return beta
-						} else if score >= beta {
-							e.skipHeight = searchHeight
-							e.skipMove = hashmove
-							e.innerLines[searchHeight].Recycle()
-							e.MovePickers[searchHeight] = e.TempMovePicker
-							score = e.alphaBeta((depthLeft+5)/3, searchHeight, beta-1, beta)
-							e.MovePickers[searchHeight] = movePicker
-							e.innerLines[searchHeight].Recycle()
-							e.skipMove = EmptyMove
-							e.skipHeight = MAX_DEPTH
+					if threshold >= beta {
+						return beta
+					} else if score >= beta {
+						e.skipHeight = searchHeight
+						e.skipMove = hashmove
+						e.innerLines[searchHeight].Recycle()
+						e.MovePickers[searchHeight] = e.TempMovePicker
+						score = e.alphaBeta((depthLeft+3)/2, searchHeight, beta-1, beta)
+						e.MovePickers[searchHeight] = movePicker
+						e.innerLines[searchHeight].Recycle()
+						e.skipMove = EmptyMove
+						e.skipHeight = MAX_DEPTH
 
-							if score >= beta+20 {
-								return beta
-							}
+						if score >= beta {
+							return beta
 						}
 					}
 				}


### PR DESCRIPTION
STC: http://chess.grantnet.us/test/24914/

```
ELO   | 3.25 +- 2.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 24936 W: 4690 L: 4457 D: 15789
```

LTC: http://chess.grantnet.us/test/24915/

```
ELO   | 1.64 +- 1.22 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 82728 W: 11130 L: 10739 D: 60859
```